### PR TITLE
chore(claude): add review-pr and audit-tests skills

### DIFF
--- a/.claude/skills/audit-tests/SKILL.md
+++ b/.claude/skills/audit-tests/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: audit-tests
+description: Audit the sabi test suite for correctness, coverage gaps, duplicates, misleading or "cheating" tests, and missing mathematical-correctness checks. Invoke as `/audit-tests` for the whole suite, or `/audit-tests <path-or-glob>` to scope to a subset (e.g. `/audit-tests tests/test_loop.py`, `/audit-tests metrics`, `/audit-tests acquisitions`). Reports findings without modifying tests.
+---
+
+# Audit the sabi Test Suite
+
+Use this skill when the user invokes `/audit-tests` (optionally with a path / module / glob argument). The deliverable is a written audit presented to the user — do **not** edit tests unless the user explicitly asks you to fix something specific afterward.
+
+The audit is a quality-of-tests review, not a coverage-percentage check. The bar is: would this test catch a real regression, and does its name truthfully describe what it asserts?
+
+## 1. Scope the audit
+
+Determine the audit scope from the argument:
+
+- No argument → full suite under `tests/`.
+- A path (e.g. `tests/test_loop.py`) → just that file.
+- A bare module name (e.g. `metrics`, `acquisitions`, `tempering`) → tests covering that source module: typically `tests/test_<module>.py` plus any test files importing from `sabi.<module>`. Use `grep -l "sabi.<module>" tests/` to identify them.
+- A glob (e.g. `tests/test_*tempering*.py`) → expand directly.
+
+State the scope explicitly back to the user as the first line of the audit, so they can confirm before reading findings.
+
+Then locate the corresponding source files and read both sides. A test audit without reading the code under test is shallow — you can't tell whether an assertion is meaningful unless you know what the function is supposed to do.
+
+For full-suite audits, read all of `tests/` and `src/sabi/` upfront if context allows; for huge suites, prioritize the load-bearing modules (`algorithms/loop.py`, `acquisitions/`, `metrics/`, `tempering/`, `surrogate/`). Note that `docs/contributing.md` says "one test file per source module where practical" — that mapping is your guide.
+
+Run the relevant tests once before auditing, so failures surface immediately:
+
+```
+scripts/python -m pytest <scope> -q
+```
+
+Per `docs/contributing.md`, prefer `scripts/python -m pytest` over bare `pytest` — the wrapper threads `PYTHONPATH` for the worktree + ProbPipe pin.
+
+If tests are failing, surface that at the top of the audit before going further. A skill that reports "all looks good" while the suite is red is worse than useless.
+
+## 2. Run the standard checks
+
+For each test file in scope, evaluate the following. Cite specific test names (`tests/test_foo.py::test_bar`) for every finding.
+
+### Correctness
+
+- Does each assertion actually verify the documented behavior, or does it just verify *something* the code happens to do?
+- Are tolerances reasonable? Per `docs/contributing.md`: 5% slack on top-level metrics is the default; tighter or looser needs a written reason. Flag tests that use a tolerance so loose it would pass even on a broken implementation.
+- Are random seeds fixed where determinism matters? Are they varied where the test is *meant* to probe seed-dependent behavior?
+- Does the test set up the right precondition? A test of `_score_single` that passes a batched array is testing the wrong contract.
+
+### Misleading or "cheating" tests
+
+These are the highest-value findings. Look for:
+
+- **Names that don't match assertions.** `test_emulator_handles_nan` that never feeds NaN to the emulator. `test_acquisition_target_terminal` that asserts on `CURRENT`.
+- **Vacuous assertions.** `assert result is not None` on a function that can't return None. `assert len(out) >= 0`. `assert isinstance(x, type(x))`.
+- **Tautological assertions.** Asserting on a value the test itself just constructed and passed in unchanged.
+- **Round-trip-on-itself.** Calling the function under test twice and comparing the outputs — confirms determinism, not correctness.
+- **Mocked-into-success.** A mock or fixture that returns the exact value the assertion checks for, so the test would pass even if the code under test were `pass`.
+- **Skip-on-failure.** `pytest.skip()` or `pytest.xfail()` used to paper over real failures rather than to mark genuinely platform-specific tests.
+- **Try/except that swallows.** `try: ...; except Exception: pass` inside a test, hiding regressions.
+- **Setup that does the work.** A test where the fixture computes the expected value using the same code path the test claims to verify — common when fixtures grow over time.
+
+For each finding, state *what* the test claims to verify (from the name or docstring) vs. *what* it actually verifies. The gap is the bug.
+
+### Duplicate / redundant tests
+
+- Multiple tests asserting the same property on the same input with different names.
+- Parametrized tests where most parameter rows exercise the same code path (the rows are symbolically distinct but functionally identical).
+- A test that's a strict subset of another, more thorough, test.
+
+Recommend consolidation, but don't be aggressive — duplicate tests are cheap, and sometimes redundancy is intentional (e.g. a focused unit test plus an integration test covering the same property).
+
+### Coverage gaps
+
+For each public function / class / method in scope, check whether at least one test exercises:
+
+- The happy path with realistic inputs.
+- Edge cases relevant to the function's contract:
+  - Single-element / empty inputs (where supported).
+  - `n_rounds == 1`, `q == 1`, `n_initial` minimal.
+  - Scalar vs. vector outputs (`output_shape == ()` vs `(p,)` with `p > 1`).
+  - Unbounded prior support (algorithms that need bounded support should error clearly).
+  - Tempering-on (non-`NoTempering`) variants.
+  - JAX trace boundaries: if a function is traced, is there a test that actually runs it under `jax.jit` / `jax.vmap`?
+- Documented error paths: each `raise` in the source should have a test that triggers it.
+
+If a public surface has no tests at all, that's a finding by itself.
+
+### Mathematical correctness
+
+This is sabi-specific and load-bearing. For every test of a function with a math formula in its docstring, check:
+
+- Is there at least one test that verifies the math against a closed-form value or a reference implementation? Smoke tests (`returns the right shape`) don't count.
+- For estimators / metrics: does the test cover a case where the *correct* value is known analytically (e.g. MMD between two equal distributions = 0, expected improvement at `f^* = mean` reduces to `sigma * phi(0)`)?
+- For samplers: is there a test that the empirical mean / variance / quantile of a large sample matches the analytical moment?
+- For tempering: do tests exist for both endpoints of the schedule (the un-tempered base and the fully-tempered terminal) where the math collapses to known limits?
+- For acquisitions: does the test verify the *score*, not just that `select_batch` returns the right shape?
+
+Flag math-bearing functions whose tests don't include at least one closed-form check. These are the tests most likely to silently rot.
+
+### Test gaps surfaced by recent changes
+
+- Skim `git log --oneline -- src/sabi/` for the scoped module since the last test addition. Bug fixes without a regression test are gaps.
+- Look for `# TODO test ...` / `# pragma: no cover` markers in source. Each is a flag worth checking.
+
+### Convention conformance
+
+- One test file per source module where practical. Flag major source modules without a `tests/test_<module>.py`.
+- Test names start with `test_`. Use of `pytest.fixture` is appropriate (not abused to hide setup the reader needs to see).
+- Numerical assertions name the tolerance choice with a comment if it's nonstandard.
+
+## 3. Write the audit
+
+Present findings in this structure. Be specific — every finding should cite `tests/<file>::<test_name>` and the source it covers (or fails to cover).
+
+```
+# Test audit: <scope>
+
+**Suite status**: <N tests, M passing, K failing/skipped>.
+
+## Critical
+- `tests/test_foo.py::test_bar` — <misleading/cheating finding, one or two sentences>.
+- ...
+
+## Coverage gaps
+- `src/sabi/<module>.py::<function>` — <what's untested and why it matters>.
+- ...
+
+## Mathematical-correctness gaps
+- <function> — <what closed-form check is missing>.
+- ...
+
+## Duplicates / consolidation candidates
+- ...
+
+## Minor
+- ...
+
+## What's solid
+- <areas with strong, meaningful test coverage — keep this honest>.
+
+## Recommendation
+<top 1–3 things worth fixing first, with a one-line rationale each>.
+```
+
+Notes:
+- Use clickable markdown links for file paths: `[tests/test_foo.py:42](tests/test_foo.py:42)`.
+- Don't pad. If a category has no findings, say "none" or omit the section.
+- Prioritize: a single misleading test that masks a real bug matters more than ten naming nits.
+- The recommendation is a *short* punch list. The user will decide what to fix.
+
+After delivering the audit, offer to: open follow-up issues for each gap, write the missing tests for a specific finding, or rerun the suite with extra options. Wait for the user to choose.

--- a/.claude/skills/audit-tests/SKILL.md
+++ b/.claude/skills/audit-tests/SKILL.md
@@ -9,6 +9,19 @@ Use this skill when the user invokes `/audit-tests` (optionally with a path / mo
 
 The audit is a quality-of-tests review, not a coverage-percentage check. The bar is: would this test catch a real regression, and does its name truthfully describe what it asserts?
 
+## Source-of-truth docs
+
+Test conventions (file-per-source-module, `scripts/python -m pytest`,
+numerical-tolerance defaults) and notation conventions (shape strings,
+public-batched / private-single-point, "target" vocabulary) live in:
+
+- [`docs/contributing.md`](../../../docs/contributing.md) — Tests section
+- [`docs/notation.md`](../../../docs/notation.md)
+
+**Read both before producing an audit.** Cite the relevant section
+when flagging a convention violation. Don't restate the rules here —
+when the docs change, the skill should keep working without edits.
+
 ## 1. Scope the audit
 
 Determine the audit scope from the argument:
@@ -22,15 +35,9 @@ State the scope explicitly back to the user as the first line of the audit, so t
 
 Then locate the corresponding source files and read both sides. A test audit without reading the code under test is shallow — you can't tell whether an assertion is meaningful unless you know what the function is supposed to do.
 
-For full-suite audits, read all of `tests/` and `src/sabi/` upfront if context allows; for huge suites, prioritize the load-bearing modules (`algorithms/loop.py`, `acquisitions/`, `metrics/`, `tempering/`, `surrogate/`). Note that `docs/contributing.md` says "one test file per source module where practical" — that mapping is your guide.
+For full-suite audits, read all of `tests/` and `src/sabi/` upfront if context allows; for huge suites, prioritize the load-bearing modules (`algorithms/loop.py`, `acquisitions/`, `metrics/`, `tempering/`, `surrogate/`). The "one test file per source module" rule in `contributing.md` is your map.
 
-Run the relevant tests once before auditing, so failures surface immediately:
-
-```
-scripts/python -m pytest <scope> -q
-```
-
-Per `docs/contributing.md`, prefer `scripts/python -m pytest` over bare `pytest` — the wrapper threads `PYTHONPATH` for the worktree + ProbPipe pin.
+Run the relevant tests once before auditing, so failures surface immediately. Use the test-runner command documented in `contributing.md`.
 
 If tests are failing, surface that at the top of the audit before going further. A skill that reports "all looks good" while the suite is red is worse than useless.
 
@@ -41,9 +48,9 @@ For each test file in scope, evaluate the following. Cite specific test names (`
 ### Correctness
 
 - Does each assertion actually verify the documented behavior, or does it just verify *something* the code happens to do?
-- Are tolerances reasonable? Per `docs/contributing.md`: 5% slack on top-level metrics is the default; tighter or looser needs a written reason. Flag tests that use a tolerance so loose it would pass even on a broken implementation.
+- Are tolerances reasonable per the rule in `contributing.md`? Flag tests that use a tolerance so loose it would pass even on a broken implementation.
 - Are random seeds fixed where determinism matters? Are they varied where the test is *meant* to probe seed-dependent behavior?
-- Does the test set up the right precondition? A test of `_score_single` that passes a batched array is testing the wrong contract.
+- Does the test set up the right precondition? A test of `_score_single` (a private single-point hook per `notation.md`) that passes a batched array is testing the wrong contract.
 
 ### Misleading or "cheating" tests
 
@@ -76,7 +83,7 @@ For each public function / class / method in scope, check whether at least one t
 - Edge cases relevant to the function's contract:
   - Single-element / empty inputs (where supported).
   - `n_rounds == 1`, `q == 1`, `n_initial` minimal.
-  - Scalar vs. vector outputs (`output_shape == ()` vs `(p,)` with `p > 1`).
+  - Scalar vs. vector outputs (`output_shape == ()` vs `(p,)` with `p > 1`) — see the shape conventions in `notation.md`.
   - Unbounded prior support (algorithms that need bounded support should error clearly).
   - Tempering-on (non-`NoTempering`) variants.
   - JAX trace boundaries: if a function is traced, is there a test that actually runs it under `jax.jit` / `jax.vmap`?
@@ -103,9 +110,7 @@ Flag math-bearing functions whose tests don't include at least one closed-form c
 
 ### Convention conformance
 
-- One test file per source module where practical. Flag major source modules without a `tests/test_<module>.py`.
-- Test names start with `test_`. Use of `pytest.fixture` is appropriate (not abused to hide setup the reader needs to see).
-- Numerical assertions name the tolerance choice with a comment if it's nonstandard.
+Walk the test files against the Tests section of `contributing.md` and the relevant parts of `notation.md`, and flag any violation. Cite the violated section by anchor.
 
 ## 3. Write the audit
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -9,6 +9,23 @@ Use this skill when the user invokes `/review-pr <number>` (or asks to review a 
 
 The goal is a careful, calibrated review: catch real problems, don't pad the report with nits. If a section has nothing to flag, say so rather than inventing concerns.
 
+## Source-of-truth docs
+
+The substantive rules — coding conventions, math-doc style, type-hint
+conventions, ProbPipe import policy, dataclass policy, shape /
+notation / "target" vocabulary, public-batched / private-single-point
+convention, the "main loops read like pseudocode" invariant, test
+conventions, numerical-tolerance defaults — all live in:
+
+- [`docs/contributing.md`](../../../docs/contributing.md)
+- [`docs/notation.md`](../../../docs/notation.md)
+
+**Read both before producing a review** and keep them open as you go.
+Cite the relevant section back to the user when flagging a violation
+(e.g. "violates `contributing.md#jax-traceability`"). Don't restate
+the rules in this skill — when the docs change, the skill should keep
+working without edits.
+
 ## 1. Fetch the PR and orient
 
 Run these in parallel with the `Bash` tool:
@@ -30,8 +47,8 @@ Cover each of the following. For each, decide "no issues", "minor", or "blocking
 
 - Does the code do what the PR / issue says it should?
 - Are there logic bugs, off-by-one errors, swapped arguments, or wrong defaults?
-- Are mathematical formulas correct? Cross-check against the docstring math (sabi puts non-trivial formulas in docstrings — they are part of the contract).
-- Concurrency / JAX trace boundaries: if the change runs inside `jax.vmap` / `jax.jit` / `jax.grad`, is it traceable per the JAX-traceability rules in `docs/contributing.md`?
+- Are mathematical formulas correct? Cross-check against the docstring math.
+- JAX trace boundaries: if the change runs inside a traced region, does it satisfy the JAX-traceability section of `contributing.md`?
 
 ### Edge cases and failure modes
 
@@ -45,41 +62,19 @@ Cover each of the following. For each, decide "no issues", "minor", or "blocking
 - Dead code, unused imports, unused parameters.
 - Duplicated logic that should be factored, OR over-abstracted helpers introduced for hypothetical future use.
 - Premature feature flags, backwards-compat shims, or `# removed: ...` comments instead of deletions.
-- Variables that shadow notation symbols (`p`, `n`, `d`, `q`, `f`, `x`, `y`) — `docs/notation.md` calls these out specifically.
+- Variables that shadow notation symbols — see `notation.md` for the reserved set.
 
-### Documentation
+### Conformance to `contributing.md` and `notation.md`
 
-- Public functions / classes / methods have docstrings.
-- Non-trivial math is in the docstring with `r"""..."""` and reST math directives (`:math:`...`` or `.. math::` blocks). Per `docs/contributing.md`: math goes in docstrings.
-- Cross-references rather than duplication: shared contracts (e.g. `PointwiseScoredAcquisition`'s scoring contract) should be referenced, not restated.
-- Symbol use matches `docs/notation.md`: `x` for parameter input (not `theta`), `f` for the target map, `X` / `Y` for batched, `n` / `d` / `p` / `q` only in math contexts.
+Walk the PR diff against each subsection of those two docs and flag any violation. The docs are the spec; the review just enforces them. Cite the violated section by anchor in your finding.
 
-### Conformance to `docs/contributing.md`
-
-Check explicitly:
-- Modern Python type hints: `collections.abc` for ABCs, `X | Y` not `Union`, built-in generics, no quoted hints unless required.
-- ProbPipe imports: top-level `from probpipe import ...` for the stable surface; only reach into `probpipe.core.*` for types without a top-level alias; no private-module imports.
-- Dataclasses: configuration bundles are `@dataclass(frozen=True)`. ABCs themselves are plain `abc.ABC` (decorate the subclass, not the ABC).
-- Tests: one test file per source module where practical, prefer `scripts/python -m pytest`, numerical-tolerance choices justified.
-
-### Conformance to `docs/notation.md`
-
-- Shape annotations match the convention (`X.shape == (n,) + input_shape`, `Y.shape == (n,) + output_shape`).
-- Public batched / private single-point convention: batched methods take `X, Y`; single-point hooks are underscore-prefixed (`_call_single`, `_score_single`).
-- "Target" terms: `target_distribution` (Distribution) vs. `target_map` (Callable) kept distinct. `IntermediateTarget`, `AcquisitionTarget` used per the glossary.
-- `emulator` (function) vs. `surrogate` (distribution) usage.
-
-### The "main loops read like pseudocode" invariant
-
-This is a sabi-specific invariant documented in `docs/contributing.md`. Apply it to any change that touches `run()` in `src/sabi/algorithms/loop.py` or any other top-level algorithm loop body that plays the same role.
-
-Ask: could a reader who knows the math but not this codebase trace the algorithm by reading only the loop body? Flag any of:
-- Branching on tempering invariance, `output_transform` plumbing, or cheap-update vs. refit dispatch in the loop body itself.
-- Inline construction of `SurrogateDistribution` / `AcquisitionState` / `MetricContext` payloads in the loop body.
-- Manual `jax.random.split(...)` interleaved with algorithmic steps.
-- Per-axis or per-target conditional reuse logic at the top level (e.g. `if invariance.both: ...`).
-
-The current `run()` body does not yet satisfy this invariant — issue #20 tracks the refactor. Don't flag pre-existing violations the PR doesn't touch, but **do** flag any new code that makes the situation worse.
+The "main loops read like pseudocode" invariant (in `contributing.md`)
+deserves an explicit mention because it's easy to violate
+incrementally: any change touching `run()` in
+`src/sabi/algorithms/loop.py` (or another top-level loop body) should
+be checked against it. Don't flag pre-existing violations the PR
+doesn't touch, but **do** flag any new code that makes the situation
+worse.
 
 ### Excessive "AI thinking" commentary
 
@@ -90,7 +85,7 @@ Flag comments that are clearly AI-generated rationalization rather than load-bea
 - Comments that hedge (`# this might break if ...` followed by no actual handling).
 - Comments restating what well-named identifiers already say.
 
-Per `docs/contributing.md` style: comments should explain non-obvious *why*, not *what*. Recommend deletion or compression for any AI-thinking-style block found.
+Recommend deletion or compression for any AI-thinking-style block found.
 
 ### Test coverage
 
@@ -98,7 +93,7 @@ This is a quick check — a deep audit is the `audit-tests` skill's job. Just ve
 - New behavior has tests, ideally in the right `tests/test_<module>.py` file.
 - Bug fixes include a regression test that fails on the old code.
 - Public API changes update the relevant tests.
-- Numerical assertions have justified tolerances (5% slack on top-level metrics is the default; tighter or looser needs a written reason).
+- Numerical tolerances are picked per the rule in `contributing.md`.
 
 If test coverage looks thin, mention it and suggest the user run `/audit-tests` for a deep pass.
 
@@ -111,7 +106,7 @@ If test coverage looks thin, mention it and suggest the user run `/audit-tests` 
 
 ## 3. Write the review
 
-Present findings to the user in this structure. Keep each item terse — file:line + one sentence is usually enough. Group by severity, not by category.
+Present findings to the user in this structure. Keep each item terse — file:line + one sentence + a citation to the violated doc section is usually enough. Group by severity, not by category.
 
 ```
 # Review: PR #<number> — <title>
@@ -121,7 +116,7 @@ Present findings to the user in this structure. Keep each item terse — file:li
 **CI status**: pass / fail / skipped checks.
 
 ## Blocking
-- [`path/to/file.py:42`](path/to/file.py:42) — <issue, one sentence>.
+- [`path/to/file.py:42`](path/to/file.py:42) — <issue, one sentence> (`contributing.md#<section>`).
 - ...
 
 ## Minor

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: review-pr
+description: Review a sabi GitHub PR by number (e.g. `/review-pr 20`). Performs a thorough code-quality pass: correctness, cleanliness, documentation, redundancy, edge cases, test coverage, and conformance to `docs/contributing.md` and `docs/notation.md`. Also enforces the "main loops read like pseudocode" invariant and flags excessive AI-generated commentary. Reports findings without modifying the PR.
+---
+
+# Review a sabi Pull Request
+
+Use this skill when the user invokes `/review-pr <number>` (or asks to review a PR by number). The argument is the GitHub PR number to review. The deliverable is a written review presented to the user — do **not** post the review to GitHub unless the user explicitly asks for that.
+
+The goal is a careful, calibrated review: catch real problems, don't pad the report with nits. If a section has nothing to flag, say so rather than inventing concerns.
+
+## 1. Fetch the PR and orient
+
+Run these in parallel with the `Bash` tool:
+
+- `gh pr view <number>` — title, body, author, state, branch.
+- `gh pr view <number> --comments` — discussion so far (decisions, scope changes, pushback).
+- `gh pr diff <number>` — the actual change.
+- `gh pr checks <number>` — CI status.
+
+Identify the PR's stated goal (from title + body), the linked issue if any (`gh issue view <linked>`), and the base/head branches. If the PR is huge, list the changed files with `gh pr view <number> --json files -q '.files[].path'` and prioritize the load-bearing files for deep reading.
+
+Read the changed files at their PR-head version, not at `main`. If a changed file's logic depends on unchanged context (a base class, a helper), read that too — reviews based only on the diff miss bugs that live in the seam between changed and unchanged code.
+
+## 2. Run the standard checks
+
+Cover each of the following. For each, decide "no issues", "minor", or "blocking", and cite specific file:line locations.
+
+### Correctness
+
+- Does the code do what the PR / issue says it should?
+- Are there logic bugs, off-by-one errors, swapped arguments, or wrong defaults?
+- Are mathematical formulas correct? Cross-check against the docstring math (sabi puts non-trivial formulas in docstrings — they are part of the contract).
+- Concurrency / JAX trace boundaries: if the change runs inside `jax.vmap` / `jax.jit` / `jax.grad`, is it traceable per the JAX-traceability rules in `docs/contributing.md`?
+
+### Edge cases and failure modes
+
+- Empty inputs, single-element inputs, single-round runs (`n_rounds == 1`), zero-batch acquisitions (`q == 0`), unbounded prior support, scalar vs. vector outputs (`output_shape == ()` vs `(p,)`).
+- NaN / inf propagation. Degenerate inputs (e.g. duplicate rows in `(X, Y)`).
+- What happens when an optional dependency / protocol is missing? Are the error messages clear and at the right boundary?
+- Tempering / `NoTempering` defaults: does the change still behave correctly when the schedule is degenerate?
+
+### Cleanliness and redundancy
+
+- Dead code, unused imports, unused parameters.
+- Duplicated logic that should be factored, OR over-abstracted helpers introduced for hypothetical future use.
+- Premature feature flags, backwards-compat shims, or `# removed: ...` comments instead of deletions.
+- Variables that shadow notation symbols (`p`, `n`, `d`, `q`, `f`, `x`, `y`) — `docs/notation.md` calls these out specifically.
+
+### Documentation
+
+- Public functions / classes / methods have docstrings.
+- Non-trivial math is in the docstring with `r"""..."""` and reST math directives (`:math:`...`` or `.. math::` blocks). Per `docs/contributing.md`: math goes in docstrings.
+- Cross-references rather than duplication: shared contracts (e.g. `PointwiseScoredAcquisition`'s scoring contract) should be referenced, not restated.
+- Symbol use matches `docs/notation.md`: `x` for parameter input (not `theta`), `f` for the target map, `X` / `Y` for batched, `n` / `d` / `p` / `q` only in math contexts.
+
+### Conformance to `docs/contributing.md`
+
+Check explicitly:
+- Modern Python type hints: `collections.abc` for ABCs, `X | Y` not `Union`, built-in generics, no quoted hints unless required.
+- ProbPipe imports: top-level `from probpipe import ...` for the stable surface; only reach into `probpipe.core.*` for types without a top-level alias; no private-module imports.
+- Dataclasses: configuration bundles are `@dataclass(frozen=True)`. ABCs themselves are plain `abc.ABC` (decorate the subclass, not the ABC).
+- Tests: one test file per source module where practical, prefer `scripts/python -m pytest`, numerical-tolerance choices justified.
+
+### Conformance to `docs/notation.md`
+
+- Shape annotations match the convention (`X.shape == (n,) + input_shape`, `Y.shape == (n,) + output_shape`).
+- Public batched / private single-point convention: batched methods take `X, Y`; single-point hooks are underscore-prefixed (`_call_single`, `_score_single`).
+- "Target" terms: `target_distribution` (Distribution) vs. `target_map` (Callable) kept distinct. `IntermediateTarget`, `AcquisitionTarget` used per the glossary.
+- `emulator` (function) vs. `surrogate` (distribution) usage.
+
+### The "main loops read like pseudocode" invariant
+
+This is a sabi-specific invariant documented in `docs/contributing.md`. Apply it to any change that touches `run()` in `src/sabi/algorithms/loop.py` or any other top-level algorithm loop body that plays the same role.
+
+Ask: could a reader who knows the math but not this codebase trace the algorithm by reading only the loop body? Flag any of:
+- Branching on tempering invariance, `output_transform` plumbing, or cheap-update vs. refit dispatch in the loop body itself.
+- Inline construction of `SurrogateDistribution` / `AcquisitionState` / `MetricContext` payloads in the loop body.
+- Manual `jax.random.split(...)` interleaved with algorithmic steps.
+- Per-axis or per-target conditional reuse logic at the top level (e.g. `if invariance.both: ...`).
+
+The current `run()` body does not yet satisfy this invariant — issue #20 tracks the refactor. Don't flag pre-existing violations the PR doesn't touch, but **do** flag any new code that makes the situation worse.
+
+### Excessive "AI thinking" commentary
+
+Flag comments that are clearly AI-generated rationalization rather than load-bearing context. Patterns to watch for:
+- Multi-paragraph block comments above a 3-line function explaining what the function does in prose.
+- Comments that narrate the obvious (`# increment counter`, `# return result`).
+- Comments that reference the chat that produced them (`# as discussed`, `# to address the user's concern about ...`).
+- Comments that hedge (`# this might break if ...` followed by no actual handling).
+- Comments restating what well-named identifiers already say.
+
+Per `docs/contributing.md` style: comments should explain non-obvious *why*, not *what*. Recommend deletion or compression for any AI-thinking-style block found.
+
+### Test coverage
+
+This is a quick check — a deep audit is the `audit-tests` skill's job. Just verify:
+- New behavior has tests, ideally in the right `tests/test_<module>.py` file.
+- Bug fixes include a regression test that fails on the old code.
+- Public API changes update the relevant tests.
+- Numerical assertions have justified tolerances (5% slack on top-level metrics is the default; tighter or looser needs a written reason).
+
+If test coverage looks thin, mention it and suggest the user run `/audit-tests` for a deep pass.
+
+### Other useful checks
+
+- **CI status**: if `gh pr checks` shows failures, mention them and look at the failure briefly.
+- **Commit hygiene**: very large unrelated changes mixed in, untouched files re-formatted, accidentally committed secrets / large binaries.
+- **Linked issue alignment**: does the PR actually solve the linked issue, or has scope drifted? Note drift if any.
+- **Breaking changes**: public API removed or renamed without deprecation. Flag and ask whether intentional.
+
+## 3. Write the review
+
+Present findings to the user in this structure. Keep each item terse — file:line + one sentence is usually enough. Group by severity, not by category.
+
+```
+# Review: PR #<number> — <title>
+
+**Summary** (1–2 sentences): what the PR does and overall impression.
+
+**CI status**: pass / fail / skipped checks.
+
+## Blocking
+- [`path/to/file.py:42`](path/to/file.py:42) — <issue, one sentence>.
+- ...
+
+## Minor
+- ...
+
+## Nits / suggestions
+- ...
+
+## What's good
+- ...
+
+## Recommendation
+<approve | request changes | comment>, with a one-line rationale.
+```
+
+Notes on writing the report:
+- Cite file paths as clickable markdown links: `[path/to/file.py:42](path/to/file.py:42)`.
+- Don't mention checks that found nothing — silence on a category means no issues.
+- Keep "What's good" honest; if the PR is mediocre, say "nothing notable to highlight" rather than fabricating praise.
+- The recommendation is your honest read. If the PR is correct and well-tested but has minor cleanup items, "approve with minor comments" is fine.
+
+After delivering the review, offer to: post it as a GitHub PR comment (`gh pr comment <number> --body-file ...`), open follow-up issues for non-blocking items, or dig deeper into any specific finding. Wait for the user to choose.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -126,6 +126,48 @@ For ABCs whose subclasses are dataclasses (e.g. `PointwiseOptimizer`,
 subclasses opt into `@dataclass(frozen=True)`. Don't decorate the
 ABC itself.
 
+## Algorithmic invariants
+
+### Main loops read like pseudocode
+
+The main algorithm loops — currently `run()` in
+[`src/sabi/algorithms/loop.py`](../src/sabi/algorithms/loop.py), and any
+future top-level loop bodies that play the same role — must read like a
+paper-style pseudocode description of the algorithm. An informed
+reader should be able to scan the loop body once and recover the
+algorithmic skeleton: state resolution → acquisition view →
+acquisition → target evaluation → round-end update → metrics →
+bookkeeping. Each step should be one named operation, ideally one line.
+
+Concretely, the per-round body should *not* expose:
+
+- Branching on tempering invariance, `output_transform` plumbing, or
+  cheap-update vs. refit dispatch — push these into named helpers.
+- Manual PRNG-key splitting interleaved with algorithmic steps —
+  resolve keys at the top of the round or inside the helper that
+  consumes them.
+- Inline construction of `SurrogateDistribution` /
+  `AcquisitionState` / `MetricContext` payloads — these are
+  bookkeeping, not algorithm.
+- Per-axis or per-target conditional reuse logic (e.g.
+  "if `invariance.both` then reuse the current intermediate") — wrap
+  in a helper whose name describes the *what*, not the *how*.
+
+The helpers carrying that complexity should have docstrings that
+explain the conditional logic and trade-offs. The loop body itself
+explains the algorithm.
+
+When reviewing a PR that touches `run()` or a similar loop, ask:
+"could a reader who knows the math but not this codebase trace the
+algorithm by reading only the loop body?" If the answer is no, the
+change needs to push complexity into helpers before it lands.
+
+> **Status note:** the current `run()` body does not yet satisfy this
+> invariant — the refactor lives in [issue #20](https://github.com/arob5/sabi/issues/20).
+> The invariant applies going forward: new contributions to the loop
+> should not make the situation worse, and the issue-#20 refactor is
+> the canonical example of how to bring it into compliance.
+
 ## Tests
 
 - One test file per source module where practical (`tests/test_loop.py`


### PR DESCRIPTION
## Summary

- Adds two project-scoped Claude Code skills under `.claude/skills/`:
  - **`/review-pr <number>`** — code-quality review of a PR by number. Covers correctness, cleanliness, edge cases, documentation, redundancy, and test coverage; checks conformance to [`docs/contributing.md`](docs/contributing.md) and [`docs/notation.md`](docs/notation.md); enforces the "main loops read like pseudocode" invariant; flags excessive AI-style commentary. Reports findings without modifying the PR.
  - **`/audit-tests [scope]`** — test-suite audit. No-arg form audits the full suite; optional argument scopes to a path (`tests/test_loop.py`), module (`metrics`), or glob. Looks for misleading / "cheating" tests, duplicates, coverage gaps, and — particularly — missing mathematical-correctness checks for math-bearing functions.
- Documents the **pseudocode-readability invariant** for main algorithm loops in [`docs/contributing.md`](docs/contributing.md), with a status note pointing at [issue #20](https://github.com/arob5/sabi/issues/20) for the in-flight refactor that brings `run()` into compliance.

## Test plan

- [ ] Run `/review-pr 20` (or another open PR) and verify the review structure, the contributing/notation conformance checks, and the invariant check fire as expected.
- [ ] Run `/audit-tests tests/test_loop.py` and confirm the scoping logic narrows correctly; check that the report cites specific test names and source files.
- [ ] Run `/audit-tests` (no arg) once to verify the full-suite path works without exhausting context.
- [ ] Skim the new contributing.md section and confirm the invariant is described clearly enough that future PRs can be checked against it.