### PR TITLE
General cleanup: test gaps, docstring trims, gaussian2d removal

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,5 +1,5 @@
 defaults:
-  - problem: gaussian2d
+  - problem: gaussian_2d
   - emulator: gp
   - acquisition: ei
   - algorithm: default

--- a/configs/problem/gaussian_2d.yaml
+++ b/configs/problem/gaussian_2d.yaml
@@ -1,4 +1,5 @@
-name: gaussian2d
+name: gaussian
+d: 2
 mean: [0.0, 0.0]
 cov:
   - [1.0, 0.5]

--- a/src/sabi/acquisitions/base.py
+++ b/src/sabi/acquisitions/base.py
@@ -11,13 +11,12 @@ families:
    greedy multi-point with fantasy imputation).
 2. **Sampling-style** (e.g. `PriorSampling`) — picks the batch by
    drawing from a distribution (the prior, the current posterior
-   estimate, a mixture, etc.). v1.4 ships only `PriorSampling`;
-   posterior Thompson sampling and mixture sampling land in v1.5+.
+   estimate, a mixture, etc.). Currently ships only `PriorSampling`;
+   posterior Thompson sampling and mixture sampling are follow-ups.
 3. **Batch-scored** (`BatchScoredAcquisition`) — provides a scalar
    `score_batch(X, state)` over a joint `q`-batch. q-EI, max-min
-   entropy, etc. Not implemented in v1.4; the abstraction is
-   structured to slot in a parallel `BatchOptimizer` hierarchy when
-   this lands (v1.5+).
+   entropy, etc. Not implemented yet; the abstraction is structured
+   to slot in a parallel `BatchOptimizer` hierarchy when this lands.
 
 The acquisition sees the current `SurrogateDistribution` (carrying the
 round's emulator and log-density form) plus an `AcquisitionState`
@@ -127,10 +126,9 @@ class AcquisitionState:
       ``problem.target_map``. Always present, regardless of any
       tempering scheme.
     - ``Y_train``: the values the round's emulator was actually trained
-      on. Under no tempering this equals ``Y_raw``. Under the upcoming
-      tempering schemes (Step 3+) this may be a state-dependent
-      transformation (e.g., ``lambda * Y_raw`` for likelihood tempering
-      via target).
+      on. Under no tempering this equals ``Y_raw``. Under tempering
+      schemes (e.g., `LikelihoodTemperingViaTarget`) this may be a
+      state-dependent transformation such as ``beta * Y_raw``.
 
     Most acquisitions only care about ``Y_train`` (it's what's
     consistent with ``state.surrogate_distribution.emulator``'s training

--- a/src/sabi/acquisitions/ei.py
+++ b/src/sabi/acquisitions/ei.py
@@ -48,17 +48,18 @@ class ExpectedImprovement(PointwiseScoredAcquisition):
     """Expected-improvement scoring; optimization delegated to `optimizer`.
 
     Args:
-        optimizer: pointwise optimizer that searches the score. Default is
-            `CandidateSetOptimizer()` (v1.x behavior). Use
-            `ContinuousMultiStartOptimizer()` for gradient-based maxima
-            or wrap with `GreedyMultiPointOptimizer(inner=...)` for `q > 1`.
+        optimizer: pointwise optimizer that searches the score. Default
+            is `CandidateSetOptimizer()`. Use `ContinuousMultiStartOptimizer()`
+            for gradient-based maxima or wrap with
+            `GreedyMultiPointOptimizer(inner=...)` for `q > 1`.
         offset: exploration offset :math:`\\ge 0` (larger → more
             exploration). Default `0.0` for noiseless surrogates;
             small positive values can stabilize EI for noisy ones.
         best_from: ``"data"`` uses `max(state.Y_train)` (the surrogate's
-            training-data max); ``"mean"`` uses the
-            emulator's predictive-mean max at `state.X` (more robust
-            for noisy labels — unused in v0/v1 noiseless setting).
+            training-data max); ``"mean"`` uses the emulator's
+            predictive-mean max at `state.X` (more robust for noisy
+            labels — currently unused since the supported targets are
+            deterministic).
     """
 
     optimizer: PointwiseOptimizer = field(default_factory=CandidateSetOptimizer)

--- a/src/sabi/acquisitions/ei.py
+++ b/src/sabi/acquisitions/ei.py
@@ -6,11 +6,11 @@ improvement is
 
 .. math::
 
-    \mathrm{EI}(x) = (\mu(x) - f^* - \xi)\, \Phi(z) + \sigma(x)\, \phi(z),
-    \quad z = \frac{\mu(x) - f^* - \xi}{\sigma(x)},
+    \mathrm{EI}(x) = (\mu(x) - f^* - \mathrm{offset})\, \Phi(z) + \sigma(x)\, \phi(z),
+    \quad z = \frac{\mu(x) - f^* - \mathrm{offset}}{\sigma(x)},
 
 where :math:`\Phi`, :math:`\phi` are the standard-Normal CDF / PDF and
-:math:`\xi \ge 0` is an `offset` controlling exploration / exploitation
+:math:`\mathrm{offset} \ge 0` controls exploration / exploitation
 (larger `offset` → more exploration). Setting :math:`\sigma(x) = 0`
 collapses EI to zero (already-evaluated points contribute nothing).
 
@@ -52,7 +52,7 @@ class ExpectedImprovement(PointwiseScoredAcquisition):
             `CandidateSetOptimizer()` (v1.x behavior). Use
             `ContinuousMultiStartOptimizer()` for gradient-based maxima
             or wrap with `GreedyMultiPointOptimizer(inner=...)` for `q > 1`.
-        offset: exploration offset :math:`\\xi \\ge 0` (larger → more
+        offset: exploration offset :math:`\\ge 0` (larger → more
             exploration). Default `0.0` for noiseless surrogates;
             small positive values can stabilize EI for noisy ones.
         best_from: ``"data"`` uses `max(state.Y_train)` (the surrogate's

--- a/src/sabi/acquisitions/optim.py
+++ b/src/sabi/acquisitions/optim.py
@@ -1,10 +1,10 @@
 r"""Pointwise optimizers for `PointwiseScoredAcquisition`.
 
-Three concrete optimizers ship in v1.4:
+Three concrete optimizers ship today:
 
 - ``CandidateSetOptimizer`` — random candidates from the design
-  distribution, scored via ``acq.score(X, state)``, top-q returned. The
-  v1.x EI behavior; cheap and the default for backwards compatibility.
+  distribution, scored via ``acq.score(X, state)``, top-q returned.
+  Cheap and the default.
 - ``ContinuousMultiStartOptimizer`` — random candidates, score-filter
   to top-`n_starts`, BFGS each in unconstrained reparameterization
   space (TFP bijector dispatched on the support `Constraint`), return
@@ -18,8 +18,8 @@ Three concrete optimizers ship in v1.4:
 
 For non-trivial supports (anything other than ``interval(low, high)``),
 ``ContinuousMultiStartOptimizer`` raises with a pointer to the
-``Constraint`` → bijector gap in ``docs/probpipe_issues.md``. The
-v1.x benchmarks all have box supports.
+``Constraint`` → bijector gap in ``docs/probpipe_issues.md``. All
+shipped benchmarks have box supports.
 
 Multi-start currently uses a Python loop over BFGS solves
 (``# TODO(vmap-multistart)``). JAX-vmap of ``optimistix.minimise``
@@ -68,7 +68,7 @@ class PointwiseOptimizer(ABC):
 
 
 # ---------------------------------------------------------------------------
-# Candidate-set: random candidates → top-q. v1.x EI's default.
+# Candidate-set: random candidates → top-q. The default optimizer.
 # ---------------------------------------------------------------------------
 
 
@@ -76,9 +76,8 @@ class PointwiseOptimizer(ABC):
 class CandidateSetOptimizer(PointwiseOptimizer):
     r"""Random candidates from a `BatchSampler`, score each, return top-q.
 
-    Cheap; gradient-free; matches v1.x EI behavior. Quality is governed
-    by ``n_candidates`` and the sampler's coverage of the high-score
-    regions. Concretely: draw
+    Cheap; gradient-free. Quality is governed by ``n_candidates`` and
+    the sampler's coverage of the high-score regions. Concretely: draw
     :math:`X \sim \text{sampler}^{n_{\text{candidates}}}`, evaluate
     :math:`s = \text{acq.score}(X, \text{state})`, return the rows of
     :math:`X` corresponding to the top-q entries of :math:`s`.
@@ -284,13 +283,13 @@ class GreedyMultiPointOptimizer(PointwiseOptimizer):
 def _make_bijector(constraint: Constraint) -> Bijector:
     """Return a TFP `Bijector` mapping unconstrained ℝ ↔ `constraint`'s support.
 
-    v1.4 supports only ``interval(low, high)`` constraints; the dispatch
-    here delegates to TFP's :class:`Sigmoid(low, high)`. For other
-    constraint types, raises ``NotImplementedError`` with a pointer to
-    the ``Constraint`` → bijector ProbPipe gap in
+    Currently supports only ``interval(low, high)`` constraints; the
+    dispatch here delegates to TFP's :class:`Sigmoid(low, high)`. For
+    other constraint types, raises ``NotImplementedError`` with a
+    pointer to the ``Constraint`` → bijector ProbPipe gap in
     ``docs/probpipe_issues.md`` (the gap is the inverse Constraint →
-    Bijector mapping ProbPipe doesn't yet ship; the bijector itself comes
-    from TFP).
+    Bijector mapping ProbPipe doesn't yet ship; the bijector itself
+    comes from TFP).
     """
     if isinstance(constraint, _Interval):
         return Sigmoid(
@@ -299,7 +298,7 @@ def _make_bijector(constraint: Constraint) -> Bijector:
         )
     raise NotImplementedError(
         f"ContinuousMultiStartOptimizer: no bijector dispatch for "
-        f"Constraint of type {type(constraint).__name__}. v1.4 supports "
-        f"only `interval(low, high)` supports. See "
+        f"Constraint of type {type(constraint).__name__}. Only "
+        f"`interval(low, high)` supports are implemented. See "
         f"docs/probpipe_issues.md: 'Constraint -> Bijector mapping'."
     )

--- a/src/sabi/acquisitions/random.py
+++ b/src/sabi/acquisitions/random.py
@@ -1,12 +1,13 @@
 """Sampling-based acquisitions.
 
 `PriorSampling` draws the next batch directly from a `BatchSampler`
-(default `PriorSampler`, which samples from `problem.prior`). It does not
-have a score; it is not a `PointwiseScoredAcquisition`. Useful as a
-baseline and as one component of a future `MixtureSampling` acquisition
-(v1.5+).
+(default `PriorSampler`, which samples from `problem.prior`). It does
+not have a score; it is not a `PointwiseScoredAcquisition`. Useful as
+a baseline and as one component of a future `MixtureSampling`
+acquisition.
 
-v1.5 will add `PosteriorThompsonSampling` and `MixtureSampling` here.
+`PosteriorThompsonSampling` and `MixtureSampling` are tracked as
+follow-ups.
 """
 
 from __future__ import annotations

--- a/src/sabi/algorithms/loop.py
+++ b/src/sabi/algorithms/loop.py
@@ -141,9 +141,9 @@ class RoundState:
 def run(problem: Problem, algorithm: Algorithm, key: Array) -> RunResult:
     """Run the sequential emulator-based inference loop.
 
-    State is explicit and flat. The emulator is re-fit each round on the
-    full `(X, Y_train)` (no incremental updates in v1.2; design doc lists
-    `condition_on`-backed updates as a v2 item).
+    State is explicit and flat. The emulator is re-fit each round on
+    the full `(X, Y_train)` unless a registered cheap-update handler
+    accepts the round's plan (see `sabi.emulators.dispatch`).
 
     Tempering integration: each round, the `tempering_scheme` produces
     an `IntermediateTarget` at the round's state. ``Y_train`` is derived

--- a/src/sabi/algorithms/loop.py
+++ b/src/sabi/algorithms/loop.py
@@ -1,43 +1,19 @@
 """Sequential-acquisition loop body.
 
-The `run` function executes one full algorithm run end-to-end given a
-`Problem`, an `Algorithm`, and a PRNG key. The `Algorithm` and
-`RunResult` dataclasses live in :mod:`sabi.algorithms.algorithm`;
-factories that build per-round `SurrogateDistribution` instances live in
-:mod:`sabi.algorithms.surrogate_distribution_factory`.
+`run()` executes one full algorithm run end-to-end. The `Algorithm`
+and `RunResult` dataclasses live in :mod:`sabi.algorithms.algorithm`;
+SP factories live in :mod:`sabi.algorithms.surrogate_distribution_factory`.
 
-Composition: initial design (drawn via `Algorithm.initial_sampler`) →
-emulator → metrics at round 0 (firing per `ScheduledMetric.every`) →
-acquisition → `SurrogateDistribution` → estimator function
-(`expected_target` by default) → metrics at round t. Tempering hooks
-present (`tempering_state` per round, `current_form` built each round);
-the default `NoTempering` + `UntemperedSchedule` make the state `None`
-every round.
+Composition (per round): initial design via `Algorithm.initial_sampler`
+→ emulator → acquisition → `SurrogateDistribution` → estimator (default
+`expected_target`) → scheduled metrics. See ``docs/design.md`` §4.14
+for the loop sketch and ``docs/notation.md`` for shape / symbol
+conventions.
 
-Per-metric scheduling: each metric in `Algorithm.metrics` is wrapped
-(if not already) in a `ScheduledMetric` carrying `every` (firing
-schedule), `target` (`CURRENT` vs `TERMINAL` intermediate), and
-`final` (also include in the post-loop `final_metrics`). Bare
-`Metric` instances auto-wrap at default config — preserves the
-"every metric every round + final eval" behavior.
-
-Metrics consume a `MetricContext` (estimate + surrogate distribution +
-problem + design data + round/state metadata) and declare their
-required ProbPipe `Supports*` protocols via the `requires` class
-attribute. The loop checks each metric's `requires` against the
-estimate distribution and raises `MissingProtocolError` on a
-mismatch. Output keys are validated upfront (via
-`validate_metric_keys`) before any emulator work happens; runtime
-collision check at the merge step catches metrics that opted out of
-upfront declaration (`keys = ()`).
-
-Shape / symbol conventions: see ``docs/notation.md``.
-
-File layout: `RoundState` (the per-round value type), then `run()`
-(public entry point), then the round-lifecycle helpers
-(`_run_initial_round`, `_run_final_eval`), then the round-orchestration
-helpers in calling order, then the inner machinery (metric eval, SP
-construction, update planning, protocol/merge utilities).
+File layout: `RoundState` (per-round value type) → `run()` (public
+entry) → round-lifecycle helpers (`_run_initial_round`,
+`_run_final_eval`) → per-round orchestration helpers in calling order
+→ inner machinery (metric eval, SP construction, update planning).
 """
 
 from __future__ import annotations

--- a/src/sabi/algorithms/surrogate_distribution_factory.py
+++ b/src/sabi/algorithms/surrogate_distribution_factory.py
@@ -2,7 +2,7 @@
 
 A `SurrogateDistributionFactory` packages the per-round
 `(emulator, form, support, prior, ...)` math primitives into a
-`SurrogateDistribution`. Two factories ship in v1.4.x:
+`SurrogateDistribution`. Two factories ship today:
 
 - `emulator_pushforward_factory` (default): wraps a fitted emulator and
   the round's log-density form into a `SurrogateDistribution` that

--- a/src/sabi/emulators/base.py
+++ b/src/sabi/emulators/base.py
@@ -1,59 +1,27 @@
 """`Emulator` — fittable predictive model for some target map.
 
-`Emulator` inherits from ProbPipe's `ArrayRandomFunction`: it IS a random
-function and gets the full shape contract for free
-(`__call__(X, joint_inputs, joint_outputs) -> Distribution`, `input_shape`,
-`output_shape`, `_validate_X`, etc.). The only addition is the abstract
-`fit(X, Y) -> Self`, which signals the algorithmic role: an emulator is
-typically constructed by conditioning a prior random function on training
-evaluations of the target.
-
-Concrete Gaussian emulators inherit from both `Emulator` and
-`GaussianRandomFunction` (diamond inheritance over `ArrayRandomFunction`,
-resolved by Python's C3 MRO). See `sabi.emulators.tinygp.gp.TinyGPEmulator`.
-
-Forward-look: ProbPipe's `condition_on(prior_rf, X=X, y=Y)` is the
-natural way to build a posterior random function from training data.
-The `fit` method here is a bridge that captures the same idea without
-requiring sabi to wire ProbPipe's full conditioning machinery yet.
-
-Naming convention: in sabi, "emulator" is reserved specifically for the
-predictive model fit to observations of the target function. The broader
-word "surrogate" denotes any approximate quantity replacing its exact
-analog (hence `SurrogateDistribution` for the surrogate of the true
-posterior).
+`Emulator` IS a ProbPipe `ArrayRandomFunction` and inherits the full
+shape contract. The only addition is the abstract `fit(X, Y) -> Self`.
+Concrete Gaussian emulators (`TinyGPEmulator`, `DSPGPEmulator`) inherit
+from both `Emulator` and `GaussianRandomFunction`. See ``docs/design.md``
+§4.3 for the architectural context and ``docs/notation.md`` for the
+"emulator" vs. "surrogate" naming convention.
 
 Latent vs. observation predictive
 ---------------------------------
 
-Sabi emulators report the **latent** posterior. Concretely:
+Sabi emulators report the **latent** posterior — `predict_*` methods
+do NOT add observation noise to the diagonal. The GP's noise term in
+the deterministic-target setting is primarily a Cholesky-stability
+regularizer; acquisitions (EI, etc.) and pushforward-based estimators
+want the latent uncertainty.
 
-- ``predict_mean(X)``: posterior mean of the latent function ``f(X)``.
-- ``predict_variance(X)``: marginal posterior variance of ``f(X)``,
-  with **no observation noise added to the diagonal**.
-- ``predict_covariance(X, joint_inputs=True)``: full posterior
-  covariance of ``f(X)``, with no observation noise added.
-
-Rationale: sabi targets sequential surrogate-based Bayesian inference
-on deterministic targets. The GP's noise term is primarily a
-Cholesky-stability regularizer rather than a model of real measurement
-noise. Acquisition functions (EI, etc.) and pushforward-based posterior
-estimators want the *latent* uncertainty — the uncertainty over the
-true function value at unobserved inputs — not the broader observation-
-predictive uncertainty.
-
-Callers that want the observation-predictive distribution can build it
-explicitly: ``Var[y* | data] = predict_variance(X) + obs_noise_variance``,
-where ``obs_noise_variance`` is read from the emulator's
-``obs_noise_variance`` property (see ``Emulator.obs_noise_variance``).
-Backends that have a fitted observation-noise variance expose it
-there (e.g. ``DSPGPEmulator`` returns the squared MAP-fitted
-``obs_stddev``); backends without one return ``None``.
-
-When noisy-target work lands and the latent vs. observation
-distinction becomes user-facing, this module will grow a separate
-``predict_obs_*`` family rather than overloading the existing
-``predict_*`` methods.
+Callers that want the observation-predictive distribution build it
+explicitly: ``Var[y* | data] = predict_variance(X) + obs_noise_variance``.
+Backends with a fitted noise term expose it via the
+``obs_noise_variance`` property; backends without one return ``None``.
+When noisy targets become user-facing, this module will grow a separate
+``predict_obs_*`` family rather than overloading the existing methods.
 """
 
 from __future__ import annotations

--- a/src/sabi/emulators/base.py
+++ b/src/sabi/emulators/base.py
@@ -12,9 +12,9 @@ Concrete Gaussian emulators inherit from both `Emulator` and
 `GaussianRandomFunction` (diamond inheritance over `ArrayRandomFunction`,
 resolved by Python's C3 MRO). See `sabi.emulators.tinygp.gp.TinyGPEmulator`.
 
-Forward-look (post-v1.2): ProbPipe's `condition_on(prior_rf, X=X, y=Y)` is
-the natural way to build a posterior random function from training data.
-The `fit` method here is a v1.x bridge that captures the same idea without
+Forward-look: ProbPipe's `condition_on(prior_rf, X=X, y=Y)` is the
+natural way to build a posterior random function from training data.
+The `fit` method here is a bridge that captures the same idea without
 requiring sabi to wire ProbPipe's full conditioning machinery yet.
 
 Naming convention: in sabi, "emulator" is reserved specifically for the
@@ -35,7 +35,7 @@ Sabi emulators report the **latent** posterior. Concretely:
   covariance of ``f(X)``, with no observation noise added.
 
 Rationale: sabi targets sequential surrogate-based Bayesian inference
-on (in v1) deterministic targets. The GP's noise term is primarily a
+on deterministic targets. The GP's noise term is primarily a
 Cholesky-stability regularizer rather than a model of real measurement
 noise. Acquisition functions (EI, etc.) and pushforward-based posterior
 estimators want the *latent* uncertainty — the uncertainty over the
@@ -50,7 +50,7 @@ Backends that have a fitted observation-noise variance expose it
 there (e.g. ``DSPGPEmulator`` returns the squared MAP-fitted
 ``obs_stddev``); backends without one return ``None``.
 
-When v2's noisy-target work lands and the latent vs. observation
+When noisy-target work lands and the latent vs. observation
 distinction becomes user-facing, this module will grow a separate
 ``predict_obs_*`` family rather than overloading the existing
 ``predict_*`` methods.

--- a/src/sabi/emulators/gp.py
+++ b/src/sabi/emulators/gp.py
@@ -123,11 +123,11 @@ def _scale_cov_to_output_space(
       ``(n*prod(out), n*prod(out))``: needs the full Kronecker; a
       plain elementwise multiply is *wrong*.
 
-    GPEmulator subclasses are scalar-output in v1, so this helper
-    currently asserts that invariant and uses the simple scalar
-    broadcast. Multi-output support will need to fan out to the
-    per-mode logic above. Keeping the helper centralized here so the
-    change is a single-file edit when that lands.
+    GPEmulator subclasses are scalar-output today, so this helper
+    asserts that invariant and uses the simple scalar broadcast.
+    Multi-output support will need to fan out to the per-mode logic
+    above. Keeping the helper centralized here so the change is a
+    single-file edit when that lands.
     """
     if output_shape != ():
         # Defensive: the constructors of all GPEmulator subclasses

--- a/src/sabi/emulators/gpjax/dsp_gp.py
+++ b/src/sabi/emulators/gpjax/dsp_gp.py
@@ -128,9 +128,9 @@ class DSPGPEmulator(GPEmulator):
     and the multi-restart MAP fit.
 
     Constructor args:
-        input_shape: ``(d,)`` — input dimensionality. Multi-output
-            not supported in v1.2.
-        output_shape: must be ``()`` (scalar output) in v1.2.
+        input_shape: ``(d,)`` — input dimensionality.
+        output_shape: must be ``()`` (scalar output) — multi-output is
+            a follow-up.
         name: optional emulator name (used for repr).
         kernel: ``"rbf"`` or ``"matern52"``. Default ``"rbf"`` matches
             Hvarfner et al. 2024.
@@ -179,7 +179,7 @@ class DSPGPEmulator(GPEmulator):
     ):
         if output_shape != ():
             raise ValueError(
-                f"DSPGPEmulator (v1.2) is scalar-output only; "
+                f"DSPGPEmulator is scalar-output only; "
                 f"got output_shape={output_shape}."
             )
         if len(input_shape) != 1:

--- a/src/sabi/emulators/tinygp/gp.py
+++ b/src/sabi/emulators/tinygp/gp.py
@@ -6,20 +6,19 @@ update dispatch. ``TinyGPEmulator`` itself owns:
 
 - The data-adaptive heuristic for the lengthscale (median nearest-
   neighbor distance × ``ls_factor``, floored). No optimization at
-  fit time; a principled hyperparameter search is deferred to v1.4+.
+  fit time; a principled hyperparameter search is a follow-up.
 - A :class:`_TinyGPCache` populated at fit time. The cache exposes
   the same ``predict_latent`` / ``predict_latent_joint`` /
   ``append_rows`` surface as the gpjax cache, so the
   ``GPEmulator`` base treats them interchangeably.
 
-After the v1.5 migration to ``GPEmulator``, ``TinyGPEmulator``
-supports joint-input covariance via ``predict_covariance(X,
+Supports joint-input covariance via ``predict_covariance(X,
 joint_inputs=True)`` and fixed-hyperparameter conditioning via
 ``condition_on(X_new, Y_new)``.
 
-v1.2 supports ``X.shape == (n,) + input_shape`` only (no extra
-leading batch axes). Add vmap-over-extra-batch support in v1.5+ if
-needed.
+Currently supports ``X.shape == (n,) + input_shape`` only (no extra
+leading batch axes); a vmap-over-extra-batch extension is a follow-up
+if a benchmark needs it.
 """
 
 from __future__ import annotations
@@ -57,7 +56,8 @@ class TinyGPEmulator(GPEmulator):
 
     Constructor args:
         input_shape: input dimensionality.
-        output_shape: must be ``()`` (scalar output) in v1.2.
+        output_shape: must be ``()`` (scalar output) — multi-output
+            is a follow-up.
         name: optional emulator name (used for repr).
         ls_factor: multiplier on the median nearest-neighbor distance
             for the data-adaptive lengthscale.

--- a/src/sabi/problems/__init__.py
+++ b/src/sabi/problems/__init__.py
@@ -6,7 +6,7 @@ Submodules expose their public API directly — there is intentionally
 1. **Cycle-breaking.** ``sabi.target_distribution`` imports
    ``sabi.problems.forms.LogDensityForm``. Loading the parent package
    runs this ``__init__``; if it eagerly imported ``Problem`` /
-   ``banana`` / ``gaussian2d`` (which all transitively depend on
+   ``banana`` / ``gaussian`` (which all transitively depend on
    ``sabi.target_distribution``), Python would see ``target_distribution``
    as partially-loaded and raise ``ImportError`` whenever the import
    chain entered via ``sabi.tempering`` or any other path that hit the
@@ -20,7 +20,7 @@ Use submodule paths for everything:
 
     from sabi.problems.forms import LogDensityForm, Identity, LogLikPlusPrior
     from sabi.problems.base import Problem, BenchmarkProblem
-    from sabi.problems.gaussian import gaussian, gaussian2d
+    from sabi.problems.gaussian import gaussian
     from sabi.problems.banana import banana
     from sabi.problems.neals_funnel import neals_funnel
     from sabi.problems.benchmarks import (

--- a/src/sabi/problems/base.py
+++ b/src/sabi/problems/base.py
@@ -52,7 +52,7 @@ class Problem:
             reference-based metrics (analytic when one fits naturally,
             otherwise an `EmpiricalDistribution` over precomputed
             samples).
-        name: human-readable benchmark name (e.g. ``"gaussian2d"``,
+        name: human-readable benchmark name (e.g. ``"gaussian"``,
             ``"banana"``). Used for cache keys and metadata.
     """
 

--- a/src/sabi/problems/base.py
+++ b/src/sabi/problems/base.py
@@ -14,7 +14,7 @@ because:
 - A `TargetDistribution` is a self-contained mathematical object that
   can be consumed by ProbPipe ops directly (`condition_on`,
   `unnormalized_log_prob`, etc.). No `Problem` wrapping required.
-- `TemperingScheme` (Step 3) operates on `TargetDistribution` to produce
+- `TemperingScheme` operates on `TargetDistribution` to produce
   intermediate targets, with no awareness of `Problem`-level metadata.
 - A future `BenchmarkProblem` (issue #2) can subclass / extend `Problem`
   with validated reference artifacts without touching the math layer.

--- a/src/sabi/problems/benchmarks.py
+++ b/src/sabi/problems/benchmarks.py
@@ -63,9 +63,8 @@ def banana_10d() -> BenchmarkProblem:
 def gaussian_2d() -> BenchmarkProblem:
     """Validated 2-D Gaussian benchmark (mean=0, cov=[[1, 0.5], [0.5, 1]]).
 
-    Preserves the historical `gaussian2d` defaults from the pre-refactor
-    factory: zero mean, unit marginal variances, off-diagonal correlation
-    0.5. Reference is the analytic ProbPipe `MultivariateNormal` itself.
+    Zero mean, unit marginal variances, off-diagonal correlation 0.5.
+    Reference is the analytic ProbPipe `MultivariateNormal` itself.
     """
     problem = gaussian(d=2, mean=(0.0, 0.0), cov=((1.0, 0.5), (0.5, 1.0)))
     return BenchmarkProblem(

--- a/src/sabi/problems/gaussian.py
+++ b/src/sabi/problems/gaussian.py
@@ -100,24 +100,3 @@ def gaussian(
         reference_distribution=posterior,
         name="gaussian",
     )
-
-
-def gaussian2d(
-    mean: tuple[float, float] = (0.0, 0.0),
-    cov: tuple[tuple[float, float], tuple[float, float]] = ((1.0, 0.5), (0.5, 1.0)),
-    bounds_radius: float = 5.0,
-) -> Problem:
-    """Build a 2-D Gaussian benchmark — historical entry point.
-
-    Thin wrapper around `gaussian(d=2, ...)` preserving the original
-    correlated-covariance default. Kept for back-compat with existing
-    configs and tests; new code should call `gaussian(d=…)` directly or
-    use `sabi.problems.benchmarks.gaussian_2d()` for the validated
-    `BenchmarkProblem` form.
-    """
-    p = gaussian(d=2, mean=mean, cov=cov, bounds_radius=bounds_radius)
-    return Problem(
-        target_distribution=p.target_distribution,
-        reference_distribution=p.reference_distribution,
-        name="gaussian2d",
-    )

--- a/src/sabi/reference/nuts.py
+++ b/src/sabi/reference/nuts.py
@@ -2,19 +2,13 @@
 
 Given a `TargetDistribution` (defined by a target function + form +
 prior + support), call `condition_on(target_dist, ...)`. ProbPipe's
-inference registry auto-dispatches to `tfp_nuts` (post-PR-#151, MCMC
-methods accept `SupportsUnnormalizedLogProb`).
+inference registry auto-dispatches to `tfp_nuts` since the
+distribution satisfies `SupportsUnnormalizedLogProb`.
 
 Diagnostics (R-hat, ESS, divergence count) are computed via ArviZ on
 the returned `ApproximateDistribution.inference_data` and embedded in
 the saved metadata. The regen script enforces minimum quality
 thresholds before allowing the artifact to land.
-
-Historical note: prior to the `TargetDistribution` introduction, this
-module carried a local `_ProblemTargetDistribution` shim that wrapped
-the problem's components into a Distribution. That shim is now
-redundant — `TargetDistribution` is itself the right Distribution and
-goes directly into `condition_on`.
 """
 
 from __future__ import annotations

--- a/src/sabi/runner/build.py
+++ b/src/sabi/runner/build.py
@@ -1,8 +1,8 @@
 """Factories mapping resolved Hydra configs to sabi objects.
 
-v0 uses plain dispatch on a `name` field rather than hydra.utils.instantiate so
-that the entry-point code is easy to read; we can migrate to `_target_` strings
-in v1 once the component tree stabilizes.
+Uses plain dispatch on a `name` field rather than `hydra.utils.instantiate`
+so that the entry-point code is easy to read; migration to `_target_`
+strings is a follow-up once the component tree stabilizes.
 """
 
 from __future__ import annotations
@@ -130,8 +130,8 @@ def _build_optimizer(cfg: DictConfig | None) -> PointwiseOptimizer:
     if name == "greedy":
         # Greedy wraps an inner optimizer. Inner config under `cfg.inner`.
         inner = _build_optimizer(cfg.get("inner", None))
-        # Imputer wiring is left minimal in v1.4: kriging_believer is the
-        # default; richer config support lands when v1.5 needs it.
+        # Imputer wiring is left minimal: kriging_believer is the
+        # default; richer config support lands when a benchmark needs it.
         return GreedyMultiPointOptimizer(inner=inner)
     raise ValueError(f"Unknown acquisition.optimizer.name={name!r}.")
 

--- a/src/sabi/runner/build.py
+++ b/src/sabi/runner/build.py
@@ -29,21 +29,13 @@ from sabi.metrics.mmd import MMD
 from sabi.metrics.scheduling import MetricTarget, ScheduledMetric
 from sabi.problems.banana import banana
 from sabi.problems.base import Problem
-from sabi.problems.gaussian import gaussian, gaussian2d
+from sabi.problems.gaussian import gaussian
 from sabi.problems.neals_funnel import neals_funnel
 from sabi.emulators import TinyGPEmulator
 
 
 def build_problem(cfg: DictConfig) -> Problem:
     name = cfg.name
-    if name == "gaussian2d":
-        # Back-compat dispatch: the historical 2-D wrapper. Use `name:
-        # gaussian` with `d: 2` for the generic d-D form.
-        return gaussian2d(
-            mean=tuple(cfg.get("mean", (0.0, 0.0))),
-            cov=tuple(tuple(row) for row in cfg.get("cov", ((1.0, 0.5), (0.5, 1.0)))),
-            bounds_radius=float(cfg.get("bounds_radius", 5.0)),
-        )
     if name == "gaussian":
         # Generic d-D dispatch. `mean` / `cov` are optional; omit to use
         # gaussian()'s defaults (zero mean, identity covariance).

--- a/src/sabi/runner/build.py
+++ b/src/sabi/runner/build.py
@@ -151,7 +151,7 @@ def _build_acquisition(cfg: DictConfig) -> Acquisition:
     if name == "ei":
         return ExpectedImprovement(
             optimizer=_build_optimizer(cfg.get("optimizer", None)),
-            offset=float(cfg.get("offset", cfg.get("xi", 0.0))),
+            offset=float(cfg.get("offset", 0.0)),
             best_from=str(cfg.get("best_from", "data")),
         )
     raise ValueError(f"Unknown acquisition.name={name!r}.")

--- a/src/sabi/sampling.py
+++ b/src/sabi/sampling.py
@@ -8,14 +8,13 @@ parameter space" — used by:
 - pointwise optimizers' candidate / seed sets (`CandidateSetOptimizer`,
   `ContinuousMultiStartOptimizer`)
 
-Each call site previously rolled its own logic on top of `sample_initial`.
-Unifying under `BatchSampler` lets users swap in Sobol, LHS, or any other
-sampling strategy at the same field they would swap a prior sampler — no
-changes to the loop or the optimizers.
+Unifying under `BatchSampler` lets users swap in Sobol, LHS, or any
+other sampling strategy at the same field they would swap a prior
+sampler — no changes to the loop or the optimizers.
 
-v1.4.1 ships one concrete sampler: `PriorSampler`, which draws i.i.d.
-samples from `problem.prior`. Sobol and LHS land alongside the first
-benchmark that needs deterministic / low-discrepancy sequences.
+Currently ships one concrete sampler: `PriorSampler`, which draws
+i.i.d. samples from `problem.prior`. Sobol and LHS land alongside the
+first benchmark that needs deterministic / low-discrepancy sequences.
 
 Output shape follows `docs/notation.md`:
 ``X.shape == (n,) + problem.input_shape``.

--- a/src/sabi/surrogate/_dirac.py
+++ b/src/sabi/surrogate/_dirac.py
@@ -3,10 +3,10 @@
 A `_DiracDistribution` is a degenerate `Distribution[Array]` concentrated at
 a single value; a `_DiracArrayRandomFunction` is a degenerate
 `RandomFunction` whose marginals are Diracs at deterministic per-input
-values. They support the protocols sabi's v1.2 random-measure plumbing
+values. They support the protocols sabi's random-measure plumbing
 needs (sampling, mean, single-point evaluation) without committing to a
-density representation, since a Dirac on a continuous space has no proper
-density.
+density representation, since a Dirac on a continuous space has no
+proper density.
 
 ProbPipe doesn't yet ship a general Dirac abstraction. These shims live in
 sabi for now; once ProbPipe lands a `Dirac[T]` (and the related

--- a/src/sabi/surrogate/estimators.py
+++ b/src/sabi/surrogate/estimators.py
@@ -127,18 +127,39 @@ class _ExpectedTargetDistribution(NumericRecordDistribution):
         return self._support_value
 
     def _unnormalized_log_prob(self, value: Array) -> Array:
+        """Plug-in posterior log-density at ``value``.
+
+        Detected by ``ndim``: single-point at rank ``len(input_shape)``,
+        batched at rank ``1 + len(input_shape)``. Avoids the shape-
+        equality misidentification trap (``(n, k)`` with ``n == k``
+        looks like a single point under shape-equality).
+        """
         x = jnp.asarray(value)
-        single = x.shape == self._input_shape
-        x_batch = x[None] if single else x
-        # Emulator is an ArrayRandomFunction; __call__(X) returns a
-        # Distribution whose `mean` is the predictive mean across the n axis.
-        pred = self._emulator(x_batch)
-        pred_mean = jnp.asarray(mean(pred))
-        if single:
+        ndim_single = len(self._input_shape)
+        if x.ndim == ndim_single:
+            if x.shape != self._input_shape:
+                raise ValueError(
+                    f"_unnormalized_log_prob: single-point input expects "
+                    f"shape {self._input_shape}, got {tuple(x.shape)}."
+                )
+            pred = self._emulator(x[None])
+            pred_mean = jnp.asarray(mean(pred))
             # Form's per-point hook; avoids vmap overhead on a single x.
             return self._form._call_single(x, pred_mean[0], prior=self._prior)
-        # Batched: form's public batched call.
-        return self._form(x, pred_mean, prior=self._prior)
+        if x.ndim == ndim_single + 1:
+            if x.shape[1:] != self._input_shape:
+                raise ValueError(
+                    f"_unnormalized_log_prob: batched input expects shape "
+                    f"(n,) + {self._input_shape}, got {tuple(x.shape)}."
+                )
+            pred = self._emulator(x)
+            pred_mean = jnp.asarray(mean(pred))
+            return self._form(x, pred_mean, prior=self._prior)
+        raise ValueError(
+            f"_unnormalized_log_prob: expected ndim {ndim_single} (single "
+            f"point) or {ndim_single + 1} (batched), got ndim={x.ndim} "
+            f"(shape={tuple(x.shape)})."
+        )
 
     def _sample(self, key, sample_shape: tuple[int, ...] = ()) -> Array:
         kwargs = dict(self._sampler_kwargs)

--- a/src/sabi/surrogate/estimators.py
+++ b/src/sabi/surrogate/estimators.py
@@ -8,20 +8,20 @@ For Dirac surrogate posteriors (`WeightedEmpiricalRandomMeasure`), all
 sensible deterministic estimators coincide and reduce to the underlying
 empirical — there's nothing random to estimate.
 
-v1.2 ships:
+Currently shipped:
 
 - `expected_target(sp)` — plug the surrogate's predictive mean into the
-  log-density form. Renamed from "plug-in mean" because it's the
-  expectation of the target map under the surrogate distribution. Biased
-  in the GP-pushforward case (the plug-in is not the same as the
-  unbiased expected posterior `mean(rm)`).
+  log-density form. The expectation of the target map under the
+  surrogate distribution. Biased in the GP-pushforward case (the
+  plug-in is not the same as the unbiased expected posterior
+  `mean(rm)`).
 
 The unbiased expected posterior is exposed via `mean(sp)` (handled by
-ProbPipe's `mean` op via `SupportsMean`). For Dirac SPs this returns the
-inner empirical; for the GP-pushforward case there is no general
-`SupportsMean` implementation in v1.2 and `mean(gp_sp)` raises.
+ProbPipe's `mean` op via `SupportsMean`). For Dirac SPs this returns
+the inner empirical; for the GP-pushforward case there is no general
+`SupportsMean` implementation today and `mean(gp_sp)` raises.
 
-Future estimators (NOT in v1.2) — see `docs/probpipe_issues.md` for the
+Future estimators — see `docs/probpipe_issues.md` for the
 partial-pushforward primitive that would generalize their construction.
 """
 

--- a/src/sabi/surrogate/surrogate_distribution.py
+++ b/src/sabi/surrogate/surrogate_distribution.py
@@ -1,49 +1,29 @@
 """`SurrogateDistribution` — random measure induced by an emulator of the
 target map composed with a `LogDensityForm`.
 
-A `SurrogateDistribution` is a ProbPipe `NumericRandomMeasure[Array]`: every
-emulator function realization defines a deterministic posterior, and the
-random measure is the distribution over these as the emulator's random
-function varies.
+A `SurrogateDistribution` is a ProbPipe `NumericRandomMeasure[Array]`:
+every emulator function realization defines a deterministic posterior,
+and the random measure is the distribution over these. Decoupled from
+`Problem`: takes math primitives directly (`support`, `prior`,
+`log_density_form`, `input_shape`); the loop pulls those from the
+`Problem` per round.
 
-Decoupled from `Problem`: takes math primitives directly (`support`,
-`prior`, `log_density_form`, `input_shape`). The algorithm loop pulls
-those from a `Problem` when constructing the SP each round.
-
-**Degenerate / no-emulator case.** `emulator=None` is allowed and
-denotes a Dirac surrogate posterior — the design points carry the
-posterior structure directly, with no underlying emulator of the target
-map. The Dirac case is concretely realized by
-`sabi.surrogate.weighted_empirical.WeightedEmpiricalRandomMeasure`,
-which is a `SurrogateDistribution` subclass with `emulator=None`. Code
-that hits this base class with a None emulator but no override raises
-`NotImplementedError`; subclasses opt into degeneracy by overriding
-the relevant protocol methods.
-
-Naming: in sabi, "emulator" is reserved for the predictive model fit
-to observations of the target function (an `ArrayRandomFunction`).
-"Surrogate" denotes any approximate quantity replacing its exact
-analog — so `SurrogateDistribution` is the surrogate of the *true*
-posterior, distinct from the emulator that approximates the target
-function.
+`emulator=None` denotes a Dirac surrogate posterior, concretely realized
+by `WeightedEmpiricalRandomMeasure`. The base class raises
+`NotImplementedError` from emulator-touching protocol methods on a
+None emulator; degenerate subclasses opt in by overriding.
 
 Protocol opt-ins:
 
 - `SupportsRandomUnnormalizedLogProb`: returns a thin `RandomFunction`
-  whose `__call__(X)` gets the emulator's predictive at `X` and pushes
-  it through the form via `pushforward_marginal` (closed-form for
-  Gaussian-affine cases, MC empirical via ProbPipe broadcasting otherwise).
-  Requires a non-None `emulator`.
-- `SupportsSampling`: NOT implemented on the base class (sabi's
-  `Emulator` doesn't yet expose function-trajectory sampling).
-  Subclasses with degenerate emulator (e.g. `WeightedEmpiricalRandomMeasure`)
-  may implement it.
-- `SupportsMean` (the unbiased "expected posterior"): NOT implemented
-  on the base class (no closed-form expected posterior; MC backend is
-  future work). Degenerate subclasses may implement it (the inner
-  empirical IS the mean for the Dirac case).
-- `SupportsRandomLogProb`: NOT implemented on the base class
-  (normalization intractable). Degenerate subclasses may implement it.
+  that pushes the emulator's predictive at `X` through the form via
+  `pushforward_marginal`. Requires a non-None `emulator`.
+- `SupportsSampling`, `SupportsMean`, `SupportsRandomLogProb`: not
+  implemented on the base; degenerate subclasses may implement them.
+
+See ``docs/design.md`` §4.5 and ``docs/notation.md`` for the full
+"emulator" vs. "surrogate" naming convention and the architectural
+context.
 """
 
 from __future__ import annotations

--- a/src/sabi/surrogate/surrogate_distribution.py
+++ b/src/sabi/surrogate/surrogate_distribution.py
@@ -27,21 +27,21 @@ analog — so `SurrogateDistribution` is the surrogate of the *true*
 posterior, distinct from the emulator that approximates the target
 function.
 
-Protocol opt-ins (v1.2):
+Protocol opt-ins:
 
 - `SupportsRandomUnnormalizedLogProb`: returns a thin `RandomFunction`
   whose `__call__(X)` gets the emulator's predictive at `X` and pushes
   it through the form via `pushforward_marginal` (closed-form for
   Gaussian-affine cases, MC empirical via ProbPipe broadcasting otherwise).
   Requires a non-None `emulator`.
-- `SupportsSampling`: NOT implemented on the base class in v1.2 (sabi's
-  `Emulator` doesn't yet expose function-trajectory sampling — v1.6).
+- `SupportsSampling`: NOT implemented on the base class (sabi's
+  `Emulator` doesn't yet expose function-trajectory sampling).
   Subclasses with degenerate emulator (e.g. `WeightedEmpiricalRandomMeasure`)
   may implement it.
-- `SupportsMean` (the unbiased "expected posterior"): NOT implemented on
-  the base class (no closed-form expected posterior; MC backend is a v2
-  item). Degenerate subclasses may implement it (the inner empirical IS
-  the mean for the Dirac case).
+- `SupportsMean` (the unbiased "expected posterior"): NOT implemented
+  on the base class (no closed-form expected posterior; MC backend is
+  future work). Degenerate subclasses may implement it (the inner
+  empirical IS the mean for the Dirac case).
 - `SupportsRandomLogProb`: NOT implemented on the base class
   (normalization intractable). Degenerate subclasses may implement it.
 """

--- a/src/sabi/target_distribution.py
+++ b/src/sabi/target_distribution.py
@@ -191,19 +191,44 @@ class TargetDistribution(NumericRecordDistribution):
 
         `value` may be a single point of shape ``input_shape`` (the
         primary contract; ProbPipe MCMC dispatches via this path) or a
-        batch of shape ``(n,) + input_shape``. Detected by shape;
-        single-point uses ``target_single`` + form's per-point hook,
+        batch of shape ``(n,) + input_shape``. Detected by ``ndim`` —
+        previously by shape equality, which misidentified ``(n, k)``
+        arrays as single points when ``input_shape == (k,)`` and
+        ``n == k``.
+
+        Single-point uses ``target_single`` + form's per-point hook;
         batched uses ``target_map`` + the form's batched call.
+
+        Raises:
+            ValueError: when ``value.ndim`` matches neither the
+                single-point rank ``len(input_shape)`` nor the batched
+                rank ``1 + len(input_shape)``.
         """
         x = jnp.asarray(value)
-        if x.shape == self._input_shape:
+        ndim_single = len(self._input_shape)
+        if x.ndim == ndim_single:
+            if x.shape != self._input_shape:
+                raise ValueError(
+                    f"_unnormalized_log_prob: single-point input expects "
+                    f"shape {self._input_shape}, got {tuple(x.shape)}."
+                )
             y = self._target_single(x)
             # Use the form's per-point hook to avoid vmap overhead on a
             # single-point call.
             return self._log_density_form._call_single(x, y, prior=self._prior)
-        # Batched (n,) + input_shape: use the form's public batched call.
-        y = self._target_map(x)
-        return self._log_density_form(x, y, prior=self._prior)
+        if x.ndim == ndim_single + 1:
+            if x.shape[1:] != self._input_shape:
+                raise ValueError(
+                    f"_unnormalized_log_prob: batched input expects shape "
+                    f"(n,) + {self._input_shape}, got {tuple(x.shape)}."
+                )
+            y = self._target_map(x)
+            return self._log_density_form(x, y, prior=self._prior)
+        raise ValueError(
+            f"_unnormalized_log_prob: expected ndim {ndim_single} (single "
+            f"point) or {ndim_single + 1} (batched), got ndim={x.ndim} "
+            f"(shape={tuple(x.shape)})."
+        )
 
 
 class IntermediateTarget(TargetDistribution):

--- a/src/sabi/tempering/base.py
+++ b/src/sabi/tempering/base.py
@@ -44,8 +44,8 @@ Concrete schemes:
 
 - `NoTempering`: identity on both axes. The intermediate is just the
   base target distribution wrapped with ``state=state``. Default.
-- (Step 4 will add) `LikelihoodTemperingViaForm` and
-  `LikelihoodTemperingViaTarget`.
+- `LikelihoodTemperingViaForm` and `LikelihoodTemperingViaTarget` (in
+  ``sabi.tempering.likelihood``).
 """
 
 from __future__ import annotations

--- a/src/sabi/tempering/base.py
+++ b/src/sabi/tempering/base.py
@@ -1,49 +1,19 @@
 """`TemperingScheme` — family of intermediate target distributions.
 
-A `TemperingScheme` defines, for each state from a `TemperingSchedule`,
-the intermediate target distribution at that state — represented as an
-`IntermediateTarget` (a `TargetDistribution` carrying both the
-state-specific target function `f_state` and form `phi_state`, plus an
-``output_transform`` adapter for cheap derivation of training data
-from cached raw evaluations).
+A `TemperingScheme` maps each state from a `TemperingSchedule` to an
+`IntermediateTarget` (a `TargetDistribution` carrying ``f_state``,
+``phi_state``, and an ``output_transform`` adapter for cheap derivation
+of training data from cached raw evaluations).
 
-**"Tempering" is sabi's name for the more general bridging
-abstraction**: a sequence of intermediate distributions connecting a
-tractable starting point to a target. Likelihood tempering (the
-schemes shipped today), annealed importance sampling,
-normalising-flow bridges, score-based bridges, and emulator
-warm-starts are all instances of the same conceptual pattern. sabi
-keeps the name `TemperingScheme` for the abstraction; if a
-non-tempering bridge lands later, the abstraction may be renamed
-`BridgingScheme` (with `LikelihoodTempering*` becoming concrete
-subtypes whose names already encode "tempering"). Until then, treat
-the docstring's "tempering" as a stand-in for the broader bridging
-operation.
-
-The scheme is the single object that the algorithm uses to advance the
-intermediate target between rounds. The `TemperingSchedule` produces
-states; the scheme consumes them to produce `IntermediateTarget`s.
-Both must agree on the state PyTree type — that's a convention
-enforced at the user / config level (the schedule and scheme need to
-be paired sensibly).
-
-Two orthogonal axes can be tempered (per ``docs/tempering.md``):
-
-- **Target axis**: the emulator's training target ``f_state`` varies
-  with state (e.g., ``f_state = beta * log_likelihood``). The
-  ``output_transform`` is non-identity; the form is invariant.
-- **Form axis**: the log-density form ``phi_state`` varies with state
-  (e.g., the form scales the likelihood term by ``beta``). The
-  ``output_transform`` is identity; the form is non-invariant.
-
-Naturally-occurring schemes pick one axis at a time. Combining both
-(`f_state` AND `phi_state` both vary) is mathematically definable but
-rarely useful.
+"Tempering" here is the general bridging abstraction; the name is kept
+because likelihood tempering is the current concrete instance. See
+``docs/design.md`` §4.11 and ``docs/tempering.md`` for the two-axes
+(target / form) decomposition and worked examples.
 
 Concrete schemes:
 
-- `NoTempering`: identity on both axes. The intermediate is just the
-  base target distribution wrapped with ``state=state``. Default.
+- `NoTempering`: identity on both axes. The intermediate equals the
+  base target wrapped with ``state=state``. Default.
 - `LikelihoodTemperingViaForm` and `LikelihoodTemperingViaTarget` (in
   ``sabi.tempering.likelihood``).
 """

--- a/src/sabi/tempering/output_transform.py
+++ b/src/sabi/tempering/output_transform.py
@@ -2,11 +2,8 @@
 
 An `IntermediateTarget`'s ``output_transform`` is the rule for turning
 cached raw evaluations of the *base* target ``f`` into training values
-``Y_train`` for the round's tempered target ``f_state``. Historically
-this was a bare callable ``(state, X, Y_raw) -> Y_train``; this module
-replaces that with a small structured value-type hierarchy.
-
-A structured `OutputTransform` knows two things:
+``Y_train`` for the round's tempered target ``f_state``. The structured
+`OutputTransform` value-type hierarchy knows two things:
 
 1. **How to apply itself.** ``apply(state, X, Y_raw) -> Y_train`` (and
    ``__call__`` delegating, so existing call sites read unchanged).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,64 @@
-"""Shared test config: enable JAX x64 so analytic references are precise."""
+"""Shared test config and fixtures."""
+
+from __future__ import annotations
 
 import jax
 
+# Enable x64 so analytic references and Cholesky-cache equivalence tests
+# have the precision they assume.
 jax.config.update("jax_enable_x64", True)
+
+
+def make_acquisition_state(
+    *,
+    problem=None,
+    n: int = 20,
+    seed: int = 0,
+):
+    """Build an `AcquisitionState` for tests of acquisitions / optimizers / imputers.
+
+    Defaults to a `gaussian2d()` problem with a fitted `TinyGPEmulator`
+    and a `SurrogateDistribution` wrapping it. Design points come from
+    `PriorSampler` — the same path used by acquisition candidate sets,
+    so the GP is trained on the same support the acquisitions will
+    explore.
+
+    Replaces the three near-identical `_state(...)` helpers that lived
+    in `test_acquisitions.py`, `test_optim.py`, and `test_fantasize.py`.
+
+    Args:
+        problem: optional `Problem`; defaults to `gaussian2d()`.
+        n: number of design points.
+        seed: PRNG seed for the initial-design draw.
+
+    Returns:
+        `AcquisitionState` with `tempering_state=None` and
+        `target_tempering_state=None` (untempered).
+    """
+    from sabi.acquisitions.base import AcquisitionState
+    from sabi.emulators import TinyGPEmulator
+    from sabi.problems.gaussian import gaussian2d
+    from sabi.sampling import PriorSampler
+    from sabi.surrogate.surrogate_distribution import SurrogateDistribution
+
+    if problem is None:
+        problem = gaussian2d()
+    X = PriorSampler().sample(problem, jax.random.key(seed), n)
+    Y = problem.target_map(X)
+    emulator = TinyGPEmulator(input_shape=problem.input_shape).fit(X, Y)
+    sp = SurrogateDistribution(
+        emulator=emulator,
+        log_density_form=problem.log_density_form,
+        support=problem.support,
+        input_shape=problem.input_shape,
+        prior=problem.prior,
+    )
+    return AcquisitionState(
+        problem=problem,
+        surrogate_distribution=sp,
+        X=X,
+        Y_raw=Y,
+        Y_train=Y,
+        tempering_state=None,
+        target_tempering_state=None,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,17 +17,17 @@ def make_acquisition_state(
 ):
     """Build an `AcquisitionState` for tests of acquisitions / optimizers / imputers.
 
-    Defaults to a `gaussian2d()` problem with a fitted `TinyGPEmulator`
-    and a `SurrogateDistribution` wrapping it. Design points come from
-    `PriorSampler` — the same path used by acquisition candidate sets,
-    so the GP is trained on the same support the acquisitions will
-    explore.
+    Defaults to the validated `gaussian_2d()` benchmark with a fitted
+    `TinyGPEmulator` and a `SurrogateDistribution` wrapping it. Design
+    points come from `PriorSampler` — the same path used by acquisition
+    candidate sets, so the GP is trained on the same support the
+    acquisitions will explore.
 
     Replaces the three near-identical `_state(...)` helpers that lived
     in `test_acquisitions.py`, `test_optim.py`, and `test_fantasize.py`.
 
     Args:
-        problem: optional `Problem`; defaults to `gaussian2d()`.
+        problem: optional `Problem`; defaults to `gaussian_2d()`.
         n: number of design points.
         seed: PRNG seed for the initial-design draw.
 
@@ -37,12 +37,12 @@ def make_acquisition_state(
     """
     from sabi.acquisitions.base import AcquisitionState
     from sabi.emulators import TinyGPEmulator
-    from sabi.problems.gaussian import gaussian2d
+    from sabi.problems.benchmarks import gaussian_2d
     from sabi.sampling import PriorSampler
     from sabi.surrogate.surrogate_distribution import SurrogateDistribution
 
     if problem is None:
-        problem = gaussian2d()
+        problem = gaussian_2d()
     X = PriorSampler().sample(problem, jax.random.key(seed), n)
     Y = problem.target_map(X)
     emulator = TinyGPEmulator(input_shape=problem.input_shape).fit(X, Y)

--- a/tests/test_acquisition_target.py
+++ b/tests/test_acquisition_target.py
@@ -21,7 +21,7 @@ from sabi.acquisitions.base import Acquisition, AcquisitionState
 from sabi.acquisitions.base import AcquisitionTarget
 from sabi.algorithms import Algorithm, run
 from sabi.emulators import TinyGPEmulator
-from sabi.problems.gaussian import gaussian2d
+from sabi.problems.benchmarks import gaussian_2d
 from sabi.tempering.likelihood import LikelihoodTemperingViaForm
 from sabi.tempering.schedule import (
     FixedSchedule,
@@ -99,7 +99,7 @@ def test_current_default_target_state_equals_current():
     """Untempered loop with default acquisition_target=CURRENT:
     target_tempering_state == tempering_state == None for every
     acquisition round."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(AcquisitionTarget.CURRENT)
     run(problem, alg, jax.random.key(0))
 
@@ -121,7 +121,7 @@ def test_next_with_fixed_schedule_advances_one_step():
     round 0 (initial design, no acquisition call) is at state 0.1.
     Round 1 acquisition: current=0.5, target=1.0.
     Round 2 acquisition: current=1.0, target=1.0 (clamped)."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     schedule = FixedSchedule(states=(0.1, 0.5, 1.0))
     alg = Algorithm(
         emulator_factory=lambda: TinyGPEmulator(input_shape=(2,)),
@@ -151,7 +151,7 @@ def test_terminal_target_state_is_terminal_for_every_round():
     `acquisition_target=TERMINAL`: every acquisition round sees
     target=1.0; currents walk through the schedule (skipping
     round 0's state, which is the initial-design round)."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     schedule = FixedSchedule(states=(0.1, 0.5, 1.0))
     alg = Algorithm(
         emulator_factory=lambda: TinyGPEmulator(input_shape=(2,)),
@@ -184,7 +184,7 @@ def test_default_acquisition_target_preserves_untempered_metrics():
     we just confirm the run completes cleanly."""
     from sabi.acquisitions.random import PriorSampling
 
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = Algorithm(
         emulator_factory=lambda: TinyGPEmulator(input_shape=(2,)),
         acquisition=PriorSampling(),
@@ -256,7 +256,7 @@ def test_via_target_with_next_lookahead_runs_to_completion():
 def test_acquisition_state_carries_target_tempering_state():
     """Smoke check the AcquisitionState constructor accepts the new field."""
     state = AcquisitionState(
-        problem=gaussian2d(),
+        problem=gaussian_2d(),
         surrogate_distribution=None,  # type: ignore[arg-type]
         X=jnp.zeros((1, 2)),
         Y_raw=jnp.zeros((1,)),

--- a/tests/test_acquisitions.py
+++ b/tests/test_acquisitions.py
@@ -11,7 +11,7 @@ from sabi.acquisitions.random import PriorSampling
 from sabi.emulators.base import Emulator
 from sabi.surrogate.surrogate_distribution import SurrogateDistribution
 from sabi.surrogate.weighted_empirical import WeightedEmpiricalRandomMeasure
-from sabi.problems.gaussian import gaussian2d
+from sabi.problems.benchmarks import gaussian_2d
 from sabi.sampling import PriorSampler
 from sabi.emulators import TinyGPEmulator
 
@@ -19,7 +19,7 @@ from tests.conftest import make_acquisition_state
 
 
 def test_prior_sampling_acquisition_shape_and_bounds():
-    problem = gaussian2d()
+    problem = gaussian_2d()
     state = make_acquisition_state(problem=problem)
     batch = PriorSampling().select_batch(state, q=4, key=jax.random.key(7))
     assert batch.shape == (4,) + problem.input_shape
@@ -28,7 +28,7 @@ def test_prior_sampling_acquisition_shape_and_bounds():
 
 
 def test_ei_acquisition_shape():
-    problem = gaussian2d()
+    problem = gaussian_2d()
     state = make_acquisition_state(problem=problem)
     batch = ExpectedImprovement(optimizer=CandidateSetOptimizer(n_candidates=512)).select_batch(
         state, q=3, key=jax.random.key(11)
@@ -39,7 +39,7 @@ def test_ei_acquisition_shape():
 def test_ei_picks_points_with_higher_emulator_mean_than_random():
     """EI is defined to prefer points with high emulator mean + variance.
     Verify directly against the emulator (decouples from GP fit quality)."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     state = make_acquisition_state(problem=problem, n=60)
 
     ei_batch = ExpectedImprovement(optimizer=CandidateSetOptimizer(n_candidates=4096)).select_batch(
@@ -57,7 +57,7 @@ def test_ei_picks_points_with_higher_emulator_mean_than_random():
 
 
 def test_ei_average_best_beats_random_average_best_across_seeds():
-    problem = gaussian2d()
+    problem = gaussian_2d()
     state = make_acquisition_state(problem=problem, n=60)
 
     ei_bests = []
@@ -106,7 +106,7 @@ def test_ei_collapses_to_zero_at_zero_variance():
     """`EI(x) = 0` whenever `σ(x) ≤ 1e-30` — the docstring promise at
     [src/sabi/acquisitions/ei.py:14]. Uses a stub emulator since the
     real GP's jitter floor keeps σ orders of magnitude above 1e-30."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     # Train Y_train so `best = max(Y_train)` is a finite scalar.
     X = PriorSampler().sample(problem, jax.random.key(0), 4)
     Y = problem.target_map(X)
@@ -137,7 +137,7 @@ def test_ei_raises_on_degenerate_surrogate_emulator():
     `WeightedEmpiricalRandomMeasure` (the no-emulator baseline) at
     `state.surrogate_distribution` should raise with a message that
     points the user at the swap."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     X = PriorSampler().sample(problem, jax.random.key(0), 8)
     Y = problem.target_map(X)
     sp = WeightedEmpiricalRandomMeasure(

--- a/tests/test_acquisitions.py
+++ b/tests/test_acquisitions.py
@@ -1,12 +1,16 @@
 import jax
 import jax.numpy as jnp
+import pytest
 from probpipe import mean
+from probpipe.distributions.continuous import Normal
 
 from sabi.acquisitions.base import AcquisitionState
 from sabi.acquisitions.ei import ExpectedImprovement
 from sabi.acquisitions.optim import CandidateSetOptimizer
 from sabi.acquisitions.random import PriorSampling
+from sabi.emulators.base import Emulator
 from sabi.surrogate.surrogate_distribution import SurrogateDistribution
+from sabi.surrogate.weighted_empirical import WeightedEmpiricalRandomMeasure
 from sabi.problems.gaussian import gaussian2d
 from sabi.sampling import PriorSampler
 from sabi.emulators import TinyGPEmulator
@@ -89,3 +93,90 @@ def test_ei_average_best_beats_random_average_best_across_seeds():
         ei_bests.append(float(jnp.max(problem.target_map(ei_batch))))
         rand_bests.append(float(jnp.max(problem.target_map(rand_batch))))
     assert sum(ei_bests) / len(ei_bests) > sum(rand_bests) / len(rand_bests)
+
+
+# -------------------------------------------------------------------------
+# Edge cases: σ=0 collapse and degenerate (emulator=None) surrogates.
+# -------------------------------------------------------------------------
+
+
+class _ConstantEmulator(Emulator):
+    """Stub emulator returning a Normal with caller-supplied loc / scale.
+
+    Used to drive `ExpectedImprovement._score_single` to the σ ≤ 1e-30
+    branch. The real `TinyGPEmulator` floors variance at `jitter`
+    (default 1e-3) so it can't reach the σ=0 path naturally.
+    """
+
+    def __init__(self, *, loc: float, scale: float, input_shape=(2,)):
+        super().__init__(input_shape=input_shape, output_shape=(), name="constant_em")
+        self._loc = float(loc)
+        self._scale = float(scale)
+
+    def fit(self, X, Y):
+        return self
+
+    def predict(self, X, *, joint_inputs=False, joint_outputs=False):
+        n = X.shape[0]
+        return Normal(
+            loc=jnp.full((n,), self._loc),
+            scale=jnp.full((n,), self._scale),
+            name="constant_pred",
+        )
+
+
+def test_ei_collapses_to_zero_at_zero_variance():
+    """`EI(x) = 0` whenever `σ(x) ≤ 1e-30` — the docstring promise at
+    [src/sabi/acquisitions/ei.py:14]. Uses a stub emulator since the
+    real GP's jitter floor keeps σ orders of magnitude above 1e-30."""
+    problem = gaussian2d()
+    # Train Y_train so `best = max(Y_train)` is a finite scalar.
+    X = PriorSampler().sample(problem, jax.random.key(0), 4)
+    Y = problem.target_map(X)
+    emulator = _ConstantEmulator(loc=0.0, scale=0.0, input_shape=problem.input_shape)
+    sp = SurrogateDistribution(
+        emulator=emulator,
+        log_density_form=problem.log_density_form,
+        support=problem.support,
+        input_shape=problem.input_shape,
+        prior=problem.prior,
+    )
+    state = AcquisitionState(
+        problem=problem,
+        surrogate_distribution=sp,
+        X=X,
+        Y_raw=Y,
+        Y_train=Y,
+        tempering_state=None,
+        target_tempering_state=None,
+    )
+    x = jnp.zeros(problem.input_shape)
+    score = float(ExpectedImprovement()._score_single(x, state))
+    assert score == pytest.approx(0.0, abs=1e-12)
+
+
+def test_ei_raises_on_degenerate_surrogate_emulator():
+    """`ExpectedImprovement` requires a non-None emulator. Using a
+    `WeightedEmpiricalRandomMeasure` (the no-emulator baseline) at
+    `state.surrogate_distribution` should raise with a message that
+    points the user at the swap."""
+    problem = gaussian2d()
+    X = PriorSampler().sample(problem, jax.random.key(0), 8)
+    Y = problem.target_map(X)
+    sp = WeightedEmpiricalRandomMeasure(
+        X=X,
+        log_weights=Y,
+        support=problem.support,
+        input_shape=problem.input_shape,
+    )
+    state = AcquisitionState(
+        problem=problem,
+        surrogate_distribution=sp,
+        X=X,
+        Y_raw=Y,
+        Y_train=Y,
+        tempering_state=None,
+        target_tempering_state=None,
+    )
+    with pytest.raises(ValueError, match="non-degenerate emulator"):
+        ExpectedImprovement().select_batch(state, q=1, key=jax.random.key(0))

--- a/tests/test_acquisitions.py
+++ b/tests/test_acquisitions.py
@@ -15,35 +15,12 @@ from sabi.problems.gaussian import gaussian2d
 from sabi.sampling import PriorSampler
 from sabi.emulators import TinyGPEmulator
 
-
-def _state(problem, key_seed=0, n=20):
-    """Build an AcquisitionState seeded by samples from problem.prior — that's
-    where acquisition candidates will also be drawn from, so the GP gets
-    trained on the same support."""
-    X = PriorSampler().sample(problem, jax.random.key(key_seed), n)
-    Y = problem.target_map(X)
-    gp = TinyGPEmulator(input_shape=problem.input_shape).fit(X, Y)
-    sp = SurrogateDistribution(
-        emulator=gp,
-        log_density_form=problem.log_density_form,
-        support=problem.support,
-        input_shape=problem.input_shape,
-        prior=problem.prior,
-    )
-    return AcquisitionState(
-        problem=problem,
-        surrogate_distribution=sp,
-        X=X,
-        Y_raw=Y,
-        Y_train=Y,
-        tempering_state=None,
-        target_tempering_state=None,
-    )
+from tests.conftest import make_acquisition_state
 
 
 def test_prior_sampling_acquisition_shape_and_bounds():
     problem = gaussian2d()
-    state = _state(problem)
+    state = make_acquisition_state(problem=problem)
     batch = PriorSampling().select_batch(state, q=4, key=jax.random.key(7))
     assert batch.shape == (4,) + problem.input_shape
     # support is interval(low, high) per element; check membership
@@ -52,7 +29,7 @@ def test_prior_sampling_acquisition_shape_and_bounds():
 
 def test_ei_acquisition_shape():
     problem = gaussian2d()
-    state = _state(problem)
+    state = make_acquisition_state(problem=problem)
     batch = ExpectedImprovement(optimizer=CandidateSetOptimizer(n_candidates=512)).select_batch(
         state, q=3, key=jax.random.key(11)
     )
@@ -63,7 +40,7 @@ def test_ei_picks_points_with_higher_emulator_mean_than_random():
     """EI is defined to prefer points with high emulator mean + variance.
     Verify directly against the emulator (decouples from GP fit quality)."""
     problem = gaussian2d()
-    state = _state(problem, n=60)
+    state = make_acquisition_state(problem=problem, n=60)
 
     ei_batch = ExpectedImprovement(optimizer=CandidateSetOptimizer(n_candidates=4096)).select_batch(
         state, q=16, key=jax.random.key(2)
@@ -81,7 +58,7 @@ def test_ei_picks_points_with_higher_emulator_mean_than_random():
 
 def test_ei_average_best_beats_random_average_best_across_seeds():
     problem = gaussian2d()
-    state = _state(problem, n=60)
+    state = make_acquisition_state(problem=problem, n=60)
 
     ei_bests = []
     rand_bests = []

--- a/tests/test_emulator_update.py
+++ b/tests/test_emulator_update.py
@@ -213,3 +213,119 @@ def test_registered_handler_check_returning_infeasible_falls_back_to_refit():
         emulator_update_registry._methods.remove(handler)
         del emulator_update_registry._name_index[handler.name]
         emulator_update_registry._sort_methods()
+
+
+# -------------------------------------------------------------------------
+# TinyGP cheap-update equivalence — mirrors the DSPGPEmulator coverage
+# in tests/test_dsp_gp.py. Handlers are typed against the abstract
+# `GPEmulator` base, so the math is shared with DSPGPEmulator; covering
+# it for TinyGPEmulator here verifies the dispatch lands on the right
+# handler and the resulting predictions match a fresh fit.
+# -------------------------------------------------------------------------
+
+
+def _fitted_tinygp(seed: int = 401, n: int = 12):
+    import jax.random as jr
+
+    key = jr.key(seed)
+    X = jr.uniform(key, (n, 2))
+    Y = jnp.sin(X[:, 0])
+    return TinyGPEmulator(input_shape=(2,)).fit(X, Y), X, Y
+
+
+def test_tinygp_rescale_outputs_factor_one_is_exact_no_op():
+    """`RescaleOutputs(factor=1.0)` is structurally a no-op: the
+    handler short-circuits and returns the input emulator unchanged.
+    Predictions should be bit-identical (no recomputation)."""
+    em, X, Y = _fitted_tinygp(seed=411)
+
+    def _exploding_factory():
+        raise AssertionError("factor=1.0 short-circuit; factory should not be called")
+
+    out = update_emulator(
+        em,
+        RescaleOutputs(factor=1.0),
+        factory=_exploding_factory,
+        X_full=X,
+        Y_full=Y,
+    )
+    # The handler returns the original instance for factor=1.0.
+    assert out is em
+
+
+def test_tinygp_rescale_then_append_dispatch_matches_compose_of_steps():
+    """`RescaleThenAppend(factor=β, X_new, Y_new)` should produce the
+    same predictions as: rescale by β, then condition_on `Y_new` in
+    new-state units. Mirrors `test_dspgp_rescale_then_append_dispatch_matches_compose_of_steps`
+    for the TinyGP backend — the handler is typed against the abstract
+    `GPEmulator` base, so coverage here verifies the right handler is
+    picked and produces the right predictions on the tinygp cache."""
+    import jax.random as jr
+
+    em, X, Y = _fitted_tinygp(seed=421)
+
+    X_new = jr.uniform(jr.key(422), (3, 2))
+    beta = 2.5
+    Y_new_at_new_state = beta * jnp.sin(X_new[:, 0])
+
+    def _exploding_factory():
+        raise AssertionError("cheap path should fire; factory should not be called")
+
+    plan = RescaleThenAppend(factor=beta, X_new=X_new, Y_new=Y_new_at_new_state)
+    em_after = update_emulator(
+        em,
+        plan,
+        factory=_exploding_factory,
+        X_full=jnp.concatenate([X, X_new], axis=0),
+        Y_full=jnp.concatenate([beta * Y, Y_new_at_new_state], axis=0),
+    )
+
+    # Two-step path: rescale (cache untouched), then condition_on the new rows.
+    em_rescaled = update_emulator(
+        em,
+        RescaleOutputs(factor=beta),
+        factory=_exploding_factory,
+        X_full=X,
+        Y_full=beta * Y,
+    )
+    em_two_step = em_rescaled.condition_on(X_new, Y_new_at_new_state)
+
+    X_test = jr.uniform(jr.key(423), (6, 2))
+    assert jnp.allclose(
+        em_after.predict_mean(X_test),
+        em_two_step.predict_mean(X_test),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    assert jnp.allclose(
+        em_after.predict_variance(X_test),
+        em_two_step.predict_variance(X_test),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+
+
+def test_tinygp_rescale_then_append_rejects_nonpositive_factor():
+    """Factor ≤ 0 is infeasible (z-scoring requires positive scale);
+    dispatch falls back to refit on the user-supplied (X_full, Y_full)."""
+    import jax.random as jr
+
+    em, X, Y = _fitted_tinygp(seed=431, n=8)
+    X_new = jr.uniform(jr.key(432), (2, 2))
+    Y_new = -jnp.sin(X_new[:, 0])
+
+    factory_calls = {"n": 0}
+
+    def _counting_factory():
+        factory_calls["n"] += 1
+        return TinyGPEmulator(input_shape=(2,))
+
+    out = update_emulator(
+        em,
+        RescaleThenAppend(factor=-1.0, X_new=X_new, Y_new=Y_new),
+        factory=_counting_factory,
+        X_full=jnp.concatenate([X, X_new], axis=0),
+        Y_full=jnp.concatenate([-Y, Y_new], axis=0),
+    )
+    assert factory_calls["n"] == 1
+    assert out._predict_cache is not None

--- a/tests/test_fantasize.py
+++ b/tests/test_fantasize.py
@@ -2,46 +2,21 @@
 
 from __future__ import annotations
 
-import jax
 import jax.numpy as jnp
 import pytest
 from probpipe import mean
 
-from sabi.acquisitions.base import AcquisitionState
 from sabi.acquisitions.fantasize import (
     ConstantLiar,
     KrigingBeliever,
 )
-from sabi.surrogate.surrogate_distribution import SurrogateDistribution
-from sabi.problems.gaussian import gaussian2d
-from sabi.emulators import TinyGPEmulator
+
+from tests.conftest import make_acquisition_state
 
 
 def _state(n: int = 20, seed: int = 0):
-    problem = gaussian2d()
-    key = jax.random.key(seed)
-    lower, upper = problem.support.low, problem.support.high
-    X = lower + (upper - lower) * jax.random.uniform(
-        key, shape=(n,) + problem.input_shape
-    )
-    Y = problem.target_map(X)
-    emulator = TinyGPEmulator(input_shape=problem.input_shape).fit(X, Y)
-    sp = SurrogateDistribution(
-        emulator=emulator,
-        log_density_form=problem.log_density_form,
-        support=problem.support,
-        input_shape=problem.input_shape,
-        prior=problem.prior,
-    )
-    return AcquisitionState(
-        problem=problem,
-        surrogate_distribution=sp,
-        X=X,
-        Y_raw=Y,
-        Y_train=Y,
-        tempering_state=None,
-        target_tempering_state=None,
-    )
+    """Local alias for the shared `make_acquisition_state` fixture builder."""
+    return make_acquisition_state(n=n, seed=seed)
 
 
 def test_kriging_believer_returns_predictive_mean():

--- a/tests/test_likelihood_tempering.py
+++ b/tests/test_likelihood_tempering.py
@@ -287,3 +287,96 @@ def test_via_form_and_via_target_match_explicit_likelihood_tempering():
     assert float(via_target._unnormalized_log_prob(x)) == pytest.approx(
         explicit, abs=1e-6
     )
+
+
+# -------------------------------------------------------------------------
+# β=0 endpoint: the prior limit. With the likelihood term zeroed out,
+# the intermediate distribution should collapse to the prior. Checks the
+# (1-β) / β factor wiring on each form variant — a sign or factor flip
+# that survives the β=1 endpoint test would surface here.
+# -------------------------------------------------------------------------
+
+
+def test_via_form_log_lik_plus_prior_at_beta_zero_recovers_prior():
+    """β=0 with `LogLikPlusPrior`: β·y + log_prior → log_prior(x)."""
+    target = _log_lik_plus_prior_target()
+    intermediate = LikelihoodTemperingViaForm().intermediate_target(target, state=0.0)
+    x = jnp.asarray([0.5, -0.3])
+    y = _quadratic_log_lik(x)  # arbitrary log-likelihood value
+    out = float(intermediate.log_density_form._call_single(x, y, prior=target.prior))
+    expected = float(jnp.asarray(log_prob(target.prior, x)))
+    assert out == pytest.approx(expected, abs=1e-6)
+
+
+def test_via_form_forward_model_at_beta_zero_recovers_prior():
+    """β=0 with `ForwardModel`: β·log_lik(x, y) + log_prior → log_prior(x)."""
+    prior = _flat_prior()
+
+    def log_lik(x, y):
+        return -0.5 * jnp.sum((y - 1.0) ** 2)
+
+    target = TargetDistribution(
+        target_single=lambda x: x,
+        name="fm_target",
+        input_shape=(2,),
+        output_shape=(2,),
+        log_density_form=ForwardModel(log_lik_from_outputs=log_lik),
+        prior=prior,
+    )
+    intermediate = LikelihoodTemperingViaForm().intermediate_target(target, state=0.0)
+    x = jnp.asarray([0.5, -0.3])
+    y = jnp.asarray([1.5, 0.5])
+    out = float(intermediate.log_density_form._call_single(x, y, prior=prior))
+    expected = float(jnp.asarray(log_prob(prior, x)))
+    assert out == pytest.approx(expected, abs=1e-6)
+
+
+def test_via_form_identity_at_beta_zero_is_pure_prior():
+    """β=0 with the geometric bridge for `Identity`:
+    (1-β)·log_prior + β·y → log_prior(x). The y term drops entirely."""
+    target = _identity_target()
+    intermediate = LikelihoodTemperingViaForm().intermediate_target(target, state=0.0)
+    x = jnp.asarray([0.5, -0.3])
+    y = jnp.asarray(3.14)  # arbitrary; should be multiplied by β=0 and disappear
+    out = float(intermediate.log_density_form._call_single(x, y, prior=target.prior))
+    expected = float(jnp.asarray(log_prob(target.prior, x)))
+    assert out == pytest.approx(expected, abs=1e-6)
+
+
+def test_via_target_at_beta_zero_recovers_prior():
+    """β=0 with `LikelihoodTemperingViaTarget`: f_state(x) = 0, so the
+    intermediate's unnormalized log-prob is `Identity-of-zero + log_prior`
+    via `LogLikPlusPrior` = log_prior(x)."""
+    target = _log_lik_plus_prior_target()
+    intermediate = LikelihoodTemperingViaTarget().intermediate_target(target, state=0.0)
+    x = jnp.asarray([0.5, -0.3])
+    # f_state(x) is identically zero at β=0.
+    assert float(intermediate.target_single(x)) == pytest.approx(0.0, abs=1e-12)
+    # _unnormalized_log_prob(x) = 0 + log_prior(x).
+    out = float(intermediate._unnormalized_log_prob(x))
+    expected = float(jnp.asarray(log_prob(target.prior, x)))
+    assert out == pytest.approx(expected, abs=1e-6)
+
+
+def test_via_target_output_transform_at_beta_zero_zeros_y_raw():
+    """β=0 collapses Y_train = β·Y_raw to the zero vector."""
+    target = _log_lik_plus_prior_target()
+    intermediate = LikelihoodTemperingViaTarget().intermediate_target(target, state=0.0)
+    X = jnp.asarray([[0.5, -0.3], [1.0, 0.0]])
+    Y_raw = jnp.asarray([1.0, -2.0])
+    out = intermediate.output_transform(intermediate.state, X, Y_raw)
+    assert jnp.allclose(out, jnp.zeros_like(Y_raw), atol=1e-12)
+
+
+def test_via_form_and_via_target_agree_at_beta_zero():
+    """Both schemes encode the same intermediate distribution; at β=0
+    both should return the prior."""
+    target = _log_lik_plus_prior_target()
+    via_form = LikelihoodTemperingViaForm().intermediate_target(target, state=0.0)
+    via_target = LikelihoodTemperingViaTarget().intermediate_target(target, state=0.0)
+    x = jnp.asarray([0.5, -0.3])
+    out_form = float(via_form._unnormalized_log_prob(x))
+    out_target = float(via_target._unnormalized_log_prob(x))
+    expected = float(jnp.asarray(log_prob(target.prior, x)))
+    assert out_form == pytest.approx(expected, abs=1e-6)
+    assert out_target == pytest.approx(expected, abs=1e-6)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -19,7 +19,7 @@ from sabi.algorithms import (
 )
 from sabi.metrics.mmd import MMD
 from sabi.problems.banana import banana
-from sabi.problems.gaussian import gaussian2d
+from sabi.problems.benchmarks import gaussian_2d
 from sabi.emulators import TinyGPEmulator
 
 
@@ -40,8 +40,8 @@ def _algorithm(
     )
 
 
-def test_loop_runs_on_gaussian2d_with_prior_sampling_acq():
-    problem = gaussian2d()
+def test_loop_runs_on_gaussian_2d_with_prior_sampling_acq():
+    problem = gaussian_2d()
     # n_rounds=5 = round 0 (initial design) + rounds 1..4 (acquisition).
     alg = _algorithm(PriorSampling(), n_rounds=5)
     result = run(problem, alg, jax.random.key(0))
@@ -67,7 +67,7 @@ def test_loop_runs_on_banana_with_ei_acq():
 
 
 def test_loop_grows_dataset_and_records_metrics():
-    problem = gaussian2d()
+    problem = gaussian_2d()
     # n_rounds=4 = round 0 (initial) + rounds 1, 2, 3 (acquisition).
     alg = _algorithm(
         ExpectedImprovement(optimizer=CandidateSetOptimizer(n_candidates=512)),
@@ -84,7 +84,7 @@ def test_loop_grows_dataset_and_records_metrics():
 
 
 def test_loop_with_no_metrics_skips_estimator():
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(PriorSampling(), n_rounds=3, metrics=())
     result = run(problem, alg, jax.random.key(4))
     assert result.final_metrics == {}
@@ -96,7 +96,7 @@ def test_loop_with_weighted_empirical_baseline():
     """No-GP baseline path: WeightedEmpiricalSurrogateDistribution produces
     a NumericEmpiricalDistribution as the estimate, which satisfies
     SupportsSampling, so MMD runs end-to-end."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(
         PriorSampling(),
         n_rounds=3,
@@ -116,17 +116,17 @@ def test_loop_with_weighted_empirical_baseline():
     assert bool(jnp.all(matches))
 
 
-def test_loop_continuous_ei_beats_candidate_set_ei_on_gaussian2d():
+def test_loop_continuous_ei_beats_candidate_set_ei_on_gaussian_2d():
     """v1.4 exit criterion: ContinuousMultiStartOptimizer-backed EI should
     yield at-or-below MMD compared to CandidateSetOptimizer-backed EI at
-    matched evaluation budgets, on gaussian2d.
+    matched evaluation budgets, on gaussian_2d.
 
     Tolerance: continuous EI must be no worse than candidate-set EI by
     more than 5 % of the candidate-set MMD². This is loose enough to
     survive seed-dependent variance with 4 acquisition rounds, but tight
     enough that a regression in the continuous optimizer would surface.
     """
-    problem = gaussian2d()
+    problem = gaussian_2d()
 
     cs_acq = ExpectedImprovement(optimizer=CandidateSetOptimizer(n_candidates=512))
     cm_acq = ExpectedImprovement(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -16,11 +16,15 @@ from sabi.metrics import (
     MissingProtocolError,
     MMD,
 )
-from sabi.problems.gaussian import gaussian2d
+from sabi.problems.benchmarks import gaussian_2d
+from sabi.problems.gaussian import gaussian
 
 
 def _problem_no_ref():
-    p = gaussian2d()
+    # Build a bare Problem (not BenchmarkProblem) so the test can set
+    # `reference_distribution=None`. The benchmark factory enforces a
+    # non-None reference at __post_init__, which would defeat the test.
+    p = gaussian(d=2, mean=(0.0, 0.0), cov=((1.0, 0.5), (0.5, 1.0)))
     return replace(p, reference_distribution=None)
 
 
@@ -58,7 +62,7 @@ def test_mmd_returns_empty_when_no_reference():
 
 def test_mmd_low_for_samples_from_reference():
     """Posterior samples drawn from the *same* reference should yield small MMD."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     samples = jnp.asarray(
         sample(
             problem.reference_distribution,
@@ -74,7 +78,7 @@ def test_mmd_low_for_samples_from_reference():
 
 
 def test_mmd_detects_shifted_samples():
-    problem = gaussian2d()
+    problem = gaussian_2d()
     samples = jnp.asarray(
         sample(
             problem.reference_distribution, key=jax.random.key(7), sample_shape=(2048,)

--- a/tests/test_mmd.py
+++ b/tests/test_mmd.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import pytest
 
 from sabi.metrics.mmd import median_heuristic_bandwidth, mmd2_unbiased, mmd_rbf
 
@@ -47,3 +48,38 @@ def test_mmd2_grows_with_mean_shift():
     # Monotonic in the mean shift (up to sampling noise).
     for v_prev, v_next in zip(values[:-1], values[1:]):
         assert v_next >= v_prev - 1e-3
+
+
+def test_mmd2_unbiased_on_independent_halves_is_near_zero():
+    """MMD²(P, P) = 0 in the population. Splitting one sample into two
+    independent halves and computing MMD² between them should give a
+    value tightly clustered around zero; with 500 vs 500 from the same
+    distribution and the median-heuristic bandwidth, < 5e-3 is a
+    comfortable cap on the U-statistic's sampling noise.
+
+    Note: passing `mmd2_unbiased(X, X)` with the *same* array twice
+    does NOT return zero — the cross-term double-counts the diagonals
+    where it shouldn't. Independent samples are the meaningful test
+    of the population-zero limit."""
+    X_full = jax.random.normal(jax.random.key(7), shape=(1000, 2))
+    X1, X2 = X_full[:500], X_full[500:]
+    mmd2 = float(mmd2_unbiased(X1, X2))
+    assert abs(mmd2) < 5e-3
+
+
+def test_mmd_rbf_clamps_negative_unbiased_to_zero():
+    """The unbiased estimator can be slightly negative for finite
+    samples; `mmd_rbf = sqrt(max(., 0))` clamps that to zero. Find
+    a seed/sample size where the unbiased estimator is negative and
+    verify the clamp produces 0.0 exactly."""
+    # 500 vs 500 from N(0, I) almost always yields a slightly-negative
+    # unbiased MMD² under the median heuristic. Check both that the
+    # raw estimator can go negative AND that mmd_rbf clamps cleanly.
+    X_full = jax.random.normal(jax.random.key(99), shape=(1000, 2))
+    X1, X2 = X_full[:500], X_full[500:]
+    mmd2 = float(mmd2_unbiased(X1, X2))
+    rbf = float(mmd_rbf(X1, X2))
+    if mmd2 < 0:
+        assert rbf == 0.0
+    else:
+        assert rbf == pytest.approx(jnp.sqrt(mmd2), abs=1e-12)

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 import pytest
 from probpipe.core.constraints import interval, positive
 
-from sabi.acquisitions.base import AcquisitionState, PointwiseScoredAcquisition
+from sabi.acquisitions.base import PointwiseScoredAcquisition
 from sabi.acquisitions.ei import ExpectedImprovement
 from sabi.acquisitions.fantasize import ConstantLiar, KrigingBeliever
 from sabi.acquisitions.optim import (
@@ -27,41 +27,18 @@ from sabi.acquisitions.optim import (
     GreedyMultiPointOptimizer,
     _make_bijector,
 )
-from sabi.surrogate.surrogate_distribution import SurrogateDistribution
-from sabi.problems.gaussian import gaussian2d
-from sabi.emulators import TinyGPEmulator
 
-
-# -------------------------------------------------------------------------
-# Fixtures
-# -------------------------------------------------------------------------
+from tests.conftest import make_acquisition_state
 
 
 def _state(n: int = 30, seed: int = 0):
-    problem = gaussian2d()
-    key = jax.random.key(seed)
-    lower, upper = problem.support.low, problem.support.high
-    X = lower + (upper - lower) * jax.random.uniform(
-        key, shape=(n,) + problem.input_shape
-    )
-    Y = problem.target_map(X)
-    emulator = TinyGPEmulator(input_shape=problem.input_shape).fit(X, Y)
-    sp = SurrogateDistribution(
-        emulator=emulator,
-        log_density_form=problem.log_density_form,
-        support=problem.support,
-        input_shape=problem.input_shape,
-        prior=problem.prior,
-    )
-    return AcquisitionState(
-        problem=problem,
-        surrogate_distribution=sp,
-        X=X,
-        Y_raw=Y,
-        Y_train=Y,
-        tempering_state=None,
-        target_tempering_state=None,
-    )
+    """Thin alias for the shared `make_acquisition_state` fixture builder.
+
+    Most call sites in this file pass only `n` and `seed`; the shared
+    helper accepts both as keyword args. Kept as a local alias to keep
+    call sites short.
+    """
+    return make_acquisition_state(n=n, seed=seed)
 
 
 class _ConcaveScore(PointwiseScoredAcquisition):

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -118,7 +118,7 @@ def test_continuous_multistart_constrained_to_support():
     """Optimum of an unbounded concave function lands inside the support box."""
     state = _state()
     # Target outside the support box (which is [mu-5, mu+5]² = [-5, 5]²
-    # for default gaussian2d). Optimizer should clamp at the boundary.
+    # for default gaussian_2d). Optimizer should clamp at the boundary.
     target = jnp.asarray([20.0, -20.0])
     optimizer = ContinuousMultiStartOptimizer(
         n_starts=4,

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -12,11 +12,12 @@ from probpipe.distributions.multivariate import MultivariateNormal
 
 from sabi.problems.banana import banana
 from sabi.problems.base import BenchmarkProblem, Problem
-from sabi.problems.gaussian import gaussian, gaussian2d
+from sabi.problems.benchmarks import gaussian_2d
+from sabi.problems.gaussian import gaussian
 
 
-def test_gaussian2d_has_expected_shapes_and_types():
-    problem = gaussian2d()
+def test_gaussian_2d_has_expected_shapes_and_types():
+    problem = gaussian_2d()
     assert problem.input_shape == (2,)
     assert problem.output_shape == ()
     assert isinstance(problem.prior, Distribution)
@@ -24,8 +25,8 @@ def test_gaussian2d_has_expected_shapes_and_types():
     assert isinstance(problem.reference_distribution, MultivariateNormal)
 
 
-def test_gaussian2d_log_prob_integrates_to_one():
-    problem = gaussian2d()
+def test_gaussian_2d_log_prob_integrates_to_one():
+    problem = gaussian_2d()
     xs = jnp.linspace(-6.0, 6.0, 300)
     ys = jnp.linspace(-6.0, 6.0, 300)
     grid = jnp.stack(jnp.meshgrid(xs, ys, indexing="ij"), axis=-1).reshape(-1, 2)
@@ -35,10 +36,10 @@ def test_gaussian2d_log_prob_integrates_to_one():
     assert total == pytest.approx(1.0, abs=1e-3)
 
 
-def test_gaussian2d_reference_distribution_samples_match_moments():
+def test_gaussian_reference_distribution_samples_match_custom_moments():
     """`reference_distribution` is the analytic MVN; sampling from it should
-    reproduce the requested mean and cov."""
-    problem = gaussian2d(mean=(1.0, -0.5), cov=((2.0, 0.3), (0.3, 1.5)))
+    reproduce the requested mean and cov when constructed via `gaussian(d=2, ...)`."""
+    problem = gaussian(d=2, mean=(1.0, -0.5), cov=((2.0, 0.3), (0.3, 1.5)))
     samples = jnp.asarray(
         sample(
             problem.reference_distribution,
@@ -96,11 +97,11 @@ def test_gaussian_rejects_invalid_bounds_radius():
         gaussian(bounds_radius=0.0)
 
 
-def test_gaussian2d_alias_preserves_correlated_default():
-    """`gaussian2d()` (the back-compat wrapper) keeps the historical
-    correlated-covariance default — sampling from its reference
-    reproduces those moments."""
-    problem = gaussian2d()
+def test_gaussian_2d_benchmark_preserves_correlated_default():
+    """`gaussian_2d()` (the validated `BenchmarkProblem` factory) ships
+    a fixed correlated covariance; sampling from its analytic reference
+    should reproduce those moments."""
+    problem = gaussian_2d()
     samples = jnp.asarray(
         sample(
             problem.reference_distribution,

--- a/tests/test_runner_build.py
+++ b/tests/test_runner_build.py
@@ -1,3 +1,4 @@
+import pytest
 from omegaconf import OmegaConf
 
 from sabi.algorithms import (
@@ -99,3 +100,63 @@ def test_build_algorithm_bare_metric_returns_metric_not_scheduled():
     alg = build_algorithm(cfg, problem=build_problem(cfg.problem))
     # The default _cfg uses just `- name: mmd` — bare.
     assert isinstance(alg.metrics[0], MMD)
+
+
+# -------------------------------------------------------------------------
+# Error paths: each `raise ValueError` in build.py exercised directly.
+# Catches typos in YAML configs at the test stage rather than at run time.
+# -------------------------------------------------------------------------
+
+
+def test_build_problem_unknown_name_raises():
+    cfg = _cfg()
+    cfg.problem.name = "not_a_real_problem"
+    with pytest.raises(ValueError, match="problem.name"):
+        build_problem(cfg.problem)
+
+
+def test_build_algorithm_unknown_emulator_name_raises():
+    cfg = _cfg()
+    problem = build_problem(cfg.problem)
+    cfg.emulator.name = "not_a_real_emulator"
+    with pytest.raises(ValueError, match="emulator.name"):
+        build_algorithm(cfg, problem=problem)
+
+
+def test_build_algorithm_unknown_acquisition_name_raises():
+    cfg = _cfg()
+    problem = build_problem(cfg.problem)
+    cfg.acquisition.name = "not_a_real_acquisition"
+    with pytest.raises(ValueError, match="acquisition.name"):
+        build_algorithm(cfg, problem=problem)
+
+
+def test_build_algorithm_unknown_optimizer_name_raises():
+    """`acquisition.optimizer.name` is a sub-dispatch under EI; a bad
+    name should raise from `_build_optimizer`."""
+    cfg = _cfg()
+    cfg.acquisition = OmegaConf.create(
+        {
+            "name": "ei",
+            "optimizer": {"name": "not_a_real_optimizer"},
+        }
+    )
+    problem = build_problem(cfg.problem)
+    with pytest.raises(ValueError, match="acquisition.optimizer.name"):
+        build_algorithm(cfg, problem=problem)
+
+
+def test_build_algorithm_unknown_metric_name_raises():
+    cfg = _cfg()
+    cfg.metrics = [{"name": "not_a_real_metric"}]
+    problem = build_problem(cfg.problem)
+    with pytest.raises(ValueError, match="metric.name"):
+        build_algorithm(cfg, problem=problem)
+
+
+def test_build_algorithm_unknown_surrogate_distribution_factory_raises():
+    cfg = _cfg()
+    cfg.algorithm.surrogate_distribution = "not_a_real_factory"
+    problem = build_problem(cfg.problem)
+    with pytest.raises(ValueError, match="surrogate_distribution"):
+        build_algorithm(cfg, problem=problem)

--- a/tests/test_runner_build.py
+++ b/tests/test_runner_build.py
@@ -15,7 +15,8 @@ from sabi.runner.build import build_algorithm, build_problem
 def _cfg(with_metric=True):
     d = {
         "problem": {
-            "name": "gaussian2d",
+            "name": "gaussian",
+            "d": 2,
             "mean": [0.0, 0.0],
             "cov": [[1.0, 0.0], [0.0, 1.0]],
             "bounds_radius": 5.0,
@@ -33,7 +34,7 @@ def _cfg(with_metric=True):
 def test_build_problem_returns_problem():
     problem = build_problem(_cfg().problem)
     assert isinstance(problem, Problem)
-    assert problem.name == "gaussian2d"
+    assert problem.name == "gaussian"
     assert problem.input_shape == (2,)
     assert problem.output_shape == ()
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -15,13 +15,13 @@ import jax.numpy as jnp
 import pytest
 
 from sabi.problems.forms import Identity
-from sabi.problems.gaussian import gaussian2d
+from sabi.problems.benchmarks import gaussian_2d
 from sabi.target_distribution import TargetDistribution
 from sabi.sampling import PriorSampler
 
 
 def test_prior_sampler_shape_and_support():
-    problem = gaussian2d()
+    problem = gaussian_2d()
     sampler = PriorSampler()
     X = sampler.sample(problem, jax.random.key(0), n=32)
     assert X.shape == (32,) + problem.input_shape
@@ -29,7 +29,7 @@ def test_prior_sampler_shape_and_support():
 
 
 def test_prior_sampler_seed_determinism_and_independence():
-    problem = gaussian2d()
+    problem = gaussian_2d()
     sampler = PriorSampler()
     X_a = sampler.sample(problem, jax.random.key(7), n=8)
     X_b = sampler.sample(problem, jax.random.key(7), n=8)

--- a/tests/test_scheduled_metrics.py
+++ b/tests/test_scheduled_metrics.py
@@ -39,7 +39,7 @@ from sabi.metrics import (
     normalize_metrics,
     validate_metric_keys,
 )
-from sabi.problems.gaussian import gaussian2d
+from sabi.problems.benchmarks import gaussian_2d
 
 
 def _algorithm(*, metrics, n_rounds=4, **kwargs):
@@ -209,7 +209,7 @@ def test_collision_caught_before_loop_starts():
     def bad_factory() -> TinyGPEmulator:
         raise RuntimeError("emulator factory should not be called")
 
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = Algorithm(
         emulator_factory=bad_factory,
         acquisition=PriorSampling(),
@@ -233,7 +233,7 @@ def test_collision_caught_before_loop_starts():
 def test_round_0_row_present_with_no_metrics():
     """Even with metrics=(), the loop emits one row per round — round 0
     has bookkeeping fields but no metric values."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(metrics=(), n_rounds=3)
     result = run(problem, alg, jax.random.key(0))
     assert len(result.per_round_metrics) == 3
@@ -249,7 +249,7 @@ def test_round_0_row_present_with_no_metrics():
 def test_bare_metric_back_compat_fires_every_round():
     """Passing a bare MMD (auto-wrapped at default config)
     should fire on every round including round 0."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(metrics=(MMD(n_estimate_samples=256, n_reference_samples=256),), n_rounds=4)
     result = run(problem, alg, jax.random.key(0))
     assert len(result.per_round_metrics) == 4
@@ -261,7 +261,7 @@ def test_bare_metric_back_compat_fires_every_round():
 
 def test_every_k_fires_only_on_matching_rounds():
     """ScheduledMetric(every=3) with n_rounds=7 → fires at rounds 0, 3, 6."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(
         metrics=(
             ScheduledMetric(
@@ -279,7 +279,7 @@ def test_every_k_fires_only_on_matching_rounds():
 
 def test_final_false_excludes_from_final_metrics():
     """final=False keeps the metric out of the final eval."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(
         metrics=(
             ScheduledMetric(
@@ -301,7 +301,7 @@ def test_final_false_excludes_from_final_metrics():
 def test_final_only_metric_via_large_every():
     """every=large, final=True: the metric appears at round 0 only
     (since only 0 % large == 0) plus final_metrics."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(
         metrics=(
             ScheduledMetric(
@@ -331,7 +331,7 @@ def test_terminal_target_differs_from_current_under_tempering():
     from sabi.tempering.likelihood import LikelihoodTemperingViaForm
     from sabi.tempering.schedule import FixedSchedule
 
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = Algorithm(
         emulator_factory=lambda: TinyGPEmulator(input_shape=(2,)),
         acquisition=PriorSampling(),
@@ -378,7 +378,7 @@ def test_surrogate_aware_metric_reads_surrogate_distribution():
             assert ctx.surrogate_distribution is not None
             return {"n_design": float(ctx.X.shape[0])}
 
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(metrics=(DesignSizeMetric(),), n_rounds=3)
     result = run(problem, alg, jax.random.key(0))
     # Round 0: 8 initial points; rounds 1, 2: 9, 10 (PriorSampling, q=1).
@@ -394,14 +394,14 @@ def test_surrogate_aware_metric_reads_surrogate_distribution():
 def test_final_estimate_populated_with_no_metrics():
     """RunResult.final_estimate is built unconditionally, regardless of
     whether any metric is final=True."""
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(metrics=(), n_rounds=3)
     result = run(problem, alg, jax.random.key(0))
     assert isinstance(result.final_estimate, Distribution)
 
 
 def test_final_estimate_populated_when_all_metrics_final_false():
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(
         metrics=(
             ScheduledMetric(
@@ -437,7 +437,7 @@ def test_runtime_collision_backstop_for_undeclared_keys():
         def __call__(self, ctx, *, key):
             return {"score": 2.0}
 
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(metrics=(UndeclaredA(), UndeclaredB()), n_rounds=2)
     with pytest.raises(ValueError, match=r"key collision.*'score'"):
         run(problem, alg, jax.random.key(0))
@@ -459,7 +459,7 @@ def test_metric_context_metric_target_reflects_wrapper():
         def __call__(self, ctx, *, key):
             return {"target_value": 1.0 if ctx.metric_target == MetricTarget.TERMINAL else 0.0}
 
-    problem = gaussian2d()
+    problem = gaussian_2d()
     alg = _algorithm(
         metrics=(
             ScheduledMetric(metric=TargetRecorder(), target=MetricTarget.TERMINAL),

--- a/tests/test_target_distribution.py
+++ b/tests/test_target_distribution.py
@@ -69,6 +69,47 @@ def test_unnormalized_log_prob_batched():
     assert jnp.allclose(out, expected, atol=1e-6)
 
 
+def test_unnormalized_log_prob_dispatches_by_ndim_not_shape_equality():
+    """A `(n=2, d=2)` batch with `input_shape=(2,)` is unambiguously a
+    batch (rank 2, not rank 1), even though `(n, d) == input_shape` is
+    True for the leading-axis match. Previous shape-equality detection
+    misidentified this as a single point. Now dispatch is by `ndim`."""
+    td = _gaussian_target()
+    # Two 2-D points, in batched form. Both `value.shape` (= (2, 2))
+    # and `input_shape` (= (2,)) start with `2`, so a shape-equality
+    # check `value.shape == input_shape` would be False here, but a
+    # single-rank check `value.ndim == 1` is also False. Either way the
+    # batched path should fire.
+    X = jnp.asarray([[1.0, 0.5], [-0.5, 1.0]])
+    out = td._unnormalized_log_prob(X)
+    expected = jax.vmap(_gaussian_target_single)(X)
+    assert out.shape == (2,)
+    assert jnp.allclose(out, expected, atol=1e-6)
+
+
+def test_unnormalized_log_prob_rejects_wrong_input_shape():
+    """A rank-1 array of the wrong size raises (single-point branch
+    expects `input_shape`)."""
+    td = _gaussian_target()
+    with pytest.raises(ValueError, match="single-point input expects"):
+        td._unnormalized_log_prob(jnp.asarray([1.0, 2.0, 3.0]))
+
+
+def test_unnormalized_log_prob_rejects_wrong_batched_trailing_shape():
+    """A rank-2 array whose trailing dims don't match `input_shape`
+    raises (batched branch validates the suffix)."""
+    td = _gaussian_target()
+    with pytest.raises(ValueError, match="batched input expects shape"):
+        td._unnormalized_log_prob(jnp.zeros((4, 3)))
+
+
+def test_unnormalized_log_prob_rejects_unsupported_ndim():
+    """Inputs neither single-point nor batched (e.g. rank-3) raise."""
+    td = _gaussian_target()
+    with pytest.raises(ValueError, match="expected ndim"):
+        td._unnormalized_log_prob(jnp.zeros((2, 3, 2)))
+
+
 def test_satisfies_supports_unnormalized_log_prob():
     td = _gaussian_target()
     assert isinstance(td, SupportsUnnormalizedLogProb)


### PR DESCRIPTION
## Summary

General cleanup PR addressing the highest-value findings from the codebase review on branch `claude/kind-zhukovsky-e9e379`. Eleven focused commits, no behavior changes outside two intentional ones (the EI `xi` alias is removed; `_unnormalized_log_prob` now raises on ambiguous shapes that previously slipped through silently). Full suite: **324 passed, 0 failed** (301 baseline + 23 new tests).

## Commits

Each commit passes the suite on its own; reviewers can drop or reorder freely.

### Tests (added coverage)
1. **`d42cb07` test(tempering): β=0 endpoint tests** — covers the prior-recovery limit on every form variant of `LikelihoodTemperingViaForm` and the `f_state=0` limit of `LikelihoodTemperingViaTarget`. Catches sign / factor flips in `(1-β) / β` wiring that the existing β=1 endpoint tests would miss.
2. **`bd1b886` test(acquisitions): EI edge cases** — σ=0 collapse via a stub `_ConstantEmulator` (real GP's jitter floor can't reach the σ=0 path); `emulator=None` raise via `WeightedEmpiricalRandomMeasure`.
3. **`57cb745` test(mmd): self-distance and clamp-to-zero** — independent halves give MMD² ≈ 0 within a tight bound; `mmd_rbf` clamps the slightly-negative unbiased estimator to exactly 0.0.
4. **`b0fdf71` test(emulators): TinyGP cheap-update equivalence** — mirrors the DSPGPEmulator coverage for `RescaleOutputs(factor=1.0)` short-circuit, `RescaleThenAppend` two-step compose-of-steps equivalence, and non-positive factor fallback.
5. **`9e6a323` test(runner): error-path coverage for build dispatch** — every `raise ValueError` in `runner/build.py` (six branches: problem, emulator, acquisition, optimizer, metric, surrogate factory) now has a triggering test.

### Refactor / consolidation
6. **`0ca30ae` test(infra): factor duplicated `_state()` builders into conftest** — three near-identical fixture builders (`test_acquisitions.py`, `test_optim.py`, `test_fantasize.py`) collapse into one shared `make_acquisition_state` in `tests/conftest.py`. ~50 LOC saved.

### Source fixes (intentional behavior changes)
7. **`8d96d08` chore(acquisitions): standardize on `offset` for ExpectedImprovement** — drop the `xi` alias from `runner/build.py`; replace `\xi` with `\mathrm{offset}` in the EI math docstring. No YAML configs in the repo use `xi`.
8. **`521075e` fix(distributions): dispatch `_unnormalized_log_prob` by ndim, not shape equality** — both `TargetDistribution._unnormalized_log_prob` and `_ExpectedTargetDistribution._unnormalized_log_prob` previously identified single vs. batched by `value.shape == input_shape`, which could misidentify an `(n, k)` batch as a single point. Now dispatches by `ndim` and raises on ambiguous inputs.
9. **`6fb4fcf` refactor(problems): remove legacy `gaussian2d()` wrapper** — drop the back-compat wrapper around `gaussian(d=2, ...)` that just renamed the result. Configs migrate to `name: gaussian` with `d: 2`; tests migrate to `gaussian_2d()` (the validated `BenchmarkProblem` factory). Filename `configs/problem/gaussian2d.yaml` → `gaussian_2d.yaml` to match the project's `<name>_<d>d` convention.

### Documentation cleanup
10. **`2b1139b` chore(docs): drop stale temporal markers from source docstrings** — phrases like "v1.4.1 ships X", "v1.x EI behavior", "post-PR-#151", "Step 3 will add" are state-at-time-of-writing and decay. Replaced with present-tense ("Currently ships X", "follow-up if a benchmark needs it") or removed when they were pure refactor chronicles. Forward-looking markers ("lands when X") are kept.
11. **`6c461f1` docs: trim duplicated rationale from module docstring preambles** — `algorithms/loop.py`, `surrogate/surrogate_distribution.py`, `emulators/base.py`, `tempering/base.py` each carried a 40–60-line preamble that duplicated material in `docs/design.md`. Per `docs/contributing.md` ("Cross-reference, don't duplicate"), these are now ~15 lines that point at the design doc. Load-bearing notes (e.g., the latent-vs-observation predictive contract on emulators) are kept.

## Items deliberately deferred to issues

The codebase review surfaced more findings than fit cleanly in a "general cleanup" PR. Each is now an issue:

- #28 — Reduce defensive `emulator=None` guards in SurrogateDistribution consumers
- #29 — Wire `BenchmarkProblem` factories into a validated regression suite
- #30 — Review `AcquisitionState.target_tempering_state` for redundancy
- #31 — Localized unit tests for tempering / acquisition / schedule edge cases
- #32 — Closed-form pinning test for GP rank-update math
- #33 — Cover `regenerate=True` in reference cache and `BenchmarkProblem` name validation
- #34 — Input validation in pointwise optimizers and MMD
- #35 — JAX-tracing safety in emulator and sample paths

ProbPipe-internal dependency items (private `_Interval` / `_name_index` imports) are tracked in `docs/probpipe_issues.md`.

## Test plan

- [x] `scripts/python -m pytest -q` → 324 passed, 0 failed, 0 skipped (~6 minutes).
- [x] `scripts/python -m pytest tests/test_likelihood_tempering.py tests/test_acquisitions.py tests/test_mmd.py tests/test_emulator_update.py tests/test_runner_build.py tests/test_target_distribution.py -q` → 78 passed.
- [ ] Reviewer sanity check: clone, `uv sync --extra dev --extra probpipe`, `scripts/python -m pytest -q` reproduces 324/324.
- [ ] Reviewer sanity check: smoke-run the Hydra entry point: `uv run python -m sabi.runner` (uses the migrated `gaussian_2d` config).
