### PR TITLE
test: localized edge-case unit tests for issue #31

### DIFF
--- a/tests/test_acquisition_target.py
+++ b/tests/test_acquisition_target.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 import pytest
 
 from sabi.acquisitions.base import Acquisition, AcquisitionState
-from sabi.acquisitions.base import AcquisitionTarget
+from sabi.acquisitions.base import AcquisitionTarget, resolve_state
 from sabi.algorithms import Algorithm, run
 from sabi.emulators import TinyGPEmulator
 from sabi.problems.benchmarks import gaussian_2d
@@ -54,6 +54,69 @@ def test_default_terminal_state_probes_via_large_round_idx():
     # Bypass the override and call the base implementation.
     base_terminal = TemperingSchedule.terminal_state(sched)
     assert base_terminal == 1.0
+
+
+# -------------------------------------------------------------------------
+# resolve_state unit tests — direct, no loop.
+# -------------------------------------------------------------------------
+
+
+def test_resolve_state_current_returns_current_state():
+    """`CURRENT` ignores the schedule and returns `current_state` verbatim."""
+    schedule = FixedSchedule(states=(0.1, 0.5, 1.0))
+    out = resolve_state(
+        AcquisitionTarget.CURRENT, schedule, round_idx=0, current_state=0.1
+    )
+    assert out == 0.1
+
+
+def test_resolve_state_next_advances_one_round():
+    """`NEXT` queries `schedule.at(round_idx + 1)`."""
+    schedule = FixedSchedule(states=(0.1, 0.5, 1.0))
+    out = resolve_state(
+        AcquisitionTarget.NEXT, schedule, round_idx=0, current_state=0.1
+    )
+    assert out == 0.5
+
+
+def test_resolve_state_next_clamps_at_last_round():
+    """At the last round, `NEXT` queries past-the-end of the schedule;
+    built-in schedules clamp to the terminal entry, so the resolved
+    state must equal `schedule.terminal_state()`."""
+    schedule = FixedSchedule(states=(0.1, 0.5, 1.0))
+    last_round = len(schedule.states) - 1  # 2: the terminal round.
+    out = resolve_state(
+        AcquisitionTarget.NEXT,
+        schedule,
+        round_idx=last_round,
+        current_state=schedule.at(last_round)[0],
+    )
+    assert out == schedule.terminal_state()
+    assert out == 1.0
+
+
+def test_resolve_state_next_clamps_for_untempered_schedule():
+    """`UntemperedSchedule` always returns `(None, True)` — `NEXT` past the
+    end still resolves to the schedule's terminal state (None)."""
+    schedule = UntemperedSchedule()
+    out = resolve_state(
+        AcquisitionTarget.NEXT, schedule, round_idx=99, current_state=None
+    )
+    assert out is None
+    assert out == schedule.terminal_state()
+
+
+def test_resolve_state_terminal_returns_terminal_state():
+    """`TERMINAL` returns `schedule.terminal_state()` regardless of round."""
+    schedule = FixedSchedule(states=(0.1, 0.5, 1.0))
+    for round_idx in (0, 1, 2, 5):
+        out = resolve_state(
+            AcquisitionTarget.TERMINAL,
+            schedule,
+            round_idx=round_idx,
+            current_state=0.1,
+        )
+        assert out == schedule.terminal_state()
 
 
 # -------------------------------------------------------------------------

--- a/tests/test_output_transform.py
+++ b/tests/test_output_transform.py
@@ -122,3 +122,61 @@ def test_diff_returns_emulator_update_subtype_or_none():
     diff_rescale = Rescale().diff(0.1, 0.9)
     assert diff_identity is None or isinstance(diff_identity, EmulatorUpdate)
     assert diff_rescale is None or isinstance(diff_rescale, EmulatorUpdate)
+
+
+# -------------------------------------------------------------------------
+# diff apply-equivalence: applying the structured diff to Y_train_a yields
+# Y_train_b. Catches sign / inverse-direction bugs in `diff`.
+# -------------------------------------------------------------------------
+
+
+def test_identity_diff_apply_equivalence():
+    """Identity transform: Y_train is invariant in state, so applying the
+    diff (a unit rescale) to Y_train_a yields Y_train_b == Y_train_a."""
+    transform = Identity()
+    X = jnp.zeros((4, 2))
+    Y_raw = jnp.asarray([1.0, -2.0, 3.5, 0.0])
+    state_a, state_b = 0.3, 0.8
+    Y_train_a = transform.apply(state_a, X, Y_raw)
+    Y_train_b = transform.apply(state_b, X, Y_raw)
+
+    diff = transform.diff(state_a, state_b)
+    assert isinstance(diff, RescaleOutputs)
+    # Apply the structured update: multiply existing Y_train by factor.
+    Y_train_a_updated = diff.factor * Y_train_a
+    assert jnp.allclose(Y_train_a_updated, Y_train_b)
+
+
+def test_rescale_diff_apply_equivalence():
+    """Rescale transform: Y_train_a = state_a * Y_raw, Y_train_b = state_b *
+    Y_raw, and diff returns RescaleOutputs(factor=state_b/state_a). Applying
+    the factor to Y_train_a recovers Y_train_b exactly."""
+    transform = Rescale()
+    X = jnp.zeros((4, 2))
+    Y_raw = jnp.asarray([1.0, -2.0, 3.5, 0.5])
+    state_a, state_b = 0.4, 0.8
+    Y_train_a = transform.apply(state_a, X, Y_raw)
+    Y_train_b = transform.apply(state_b, X, Y_raw)
+
+    diff = transform.diff(state_a, state_b)
+    assert isinstance(diff, RescaleOutputs)
+    # Apply the structured update to Y_train_a; should equal a fresh apply
+    # at state_b.
+    Y_train_a_updated = diff.factor * Y_train_a
+    assert jnp.allclose(Y_train_a_updated, Y_train_b)
+
+
+def test_rescale_diff_apply_equivalence_reversed_direction():
+    """Same equivalence but going from a larger state to a smaller one —
+    catches sign / inverse-direction bugs (e.g., a/b vs b/a)."""
+    transform = Rescale()
+    X = jnp.zeros((3, 2))
+    Y_raw = jnp.asarray([2.0, -1.5, 0.25])
+    state_a, state_b = 0.9, 0.3
+    Y_train_a = transform.apply(state_a, X, Y_raw)
+    Y_train_b = transform.apply(state_b, X, Y_raw)
+
+    diff = transform.diff(state_a, state_b)
+    assert isinstance(diff, RescaleOutputs)
+    Y_train_a_updated = diff.factor * Y_train_a
+    assert jnp.allclose(Y_train_a_updated, Y_train_b)

--- a/tests/test_tempering.py
+++ b/tests/test_tempering.py
@@ -14,7 +14,7 @@ from sabi.problems.base import Problem
 from sabi.problems.forms import Identity
 from sabi.target_distribution import IntermediateTarget, TargetDistribution
 from sabi.tempering.base import NoTempering, TemperingScheme
-from sabi.tempering.schedule import FixedSchedule, UntemperedSchedule
+from sabi.tempering.schedule import FixedSchedule, TemperingSchedule, UntemperedSchedule
 
 
 def _box_prior():
@@ -151,6 +151,44 @@ def test_fixed_schedule_accepts_non_scalar_states():
 def test_fixed_schedule_rejects_empty():
     with pytest.raises(ValueError):
         FixedSchedule(states=())
+
+
+# -------------------------------------------------------------------------
+# TemperingSchedule.terminal_state default fallback
+# -------------------------------------------------------------------------
+
+
+def test_terminal_state_default_success_path_for_converging_subclass():
+    """A subclass that overrides only `at` (and clamps past-the-end to a
+    terminal state) gets a working `terminal_state()` for free via the
+    base default, which probes `at(10**9)`."""
+
+    class _ConvergingSchedule(TemperingSchedule):
+        """Returns a non-terminal state for round 0, terminal thereafter."""
+
+        def at(self, round_idx: int):
+            if round_idx == 0:
+                return 0.5, False
+            return 1.0, True
+
+    sched = _ConvergingSchedule()
+    # The override is omitted — the base default kicks in.
+    assert sched.terminal_state() == 1.0
+
+
+def test_terminal_state_default_raise_path_for_nonconverging_subclass():
+    """A subclass whose `at` never returns `is_terminal_state=True` causes
+    the base default to raise `NotImplementedError`."""
+
+    class _NeverTerminalSchedule(TemperingSchedule):
+        """Always returns `(state, False)` — never converges to terminal."""
+
+        def at(self, round_idx: int):
+            return float(round_idx), False
+
+    sched = _NeverTerminalSchedule()
+    with pytest.raises(NotImplementedError, match="did not"):
+        sched.terminal_state()
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #31. Adds direct unit tests for three small edge-case behaviors that were previously exercised only transitively through the end-to-end loop. Localizing them surfaces regressions earlier and more clearly.

PR #36 (the dependency) is already merged; this branch builds on top.

### New tests

**`tests/test_output_transform.py`** — diff apply-equivalence (3 tests)
- `test_identity_diff_apply_equivalence`: `Identity` is state-invariant, so applying its diff (a unit rescale) to `Y_train_a` must equal `Y_train_b`.
- `test_rescale_diff_apply_equivalence`: `Rescale` produces `Y_train = state * Y_raw`; applying `RescaleOutputs(state_b/state_a)` to `Y_train_a` must equal a fresh `apply(state_b, X, Y_raw)`.
- `test_rescale_diff_apply_equivalence_reversed_direction`: same equivalence going `large -> small` state. Catches sign / inverse-direction bugs (e.g., `a/b` vs `b/a`).

**`tests/test_acquisition_target.py`** — `resolve_state` unit tests (5 tests)
- `test_resolve_state_current_returns_current_state`
- `test_resolve_state_next_advances_one_round`
- `test_resolve_state_next_clamps_at_last_round`: directly asserts `resolve_state(NEXT, schedule, last_round, ...) == schedule.terminal_state()`.
- `test_resolve_state_next_clamps_for_untempered_schedule`
- `test_resolve_state_terminal_returns_terminal_state`

**`tests/test_tempering.py`** — `TemperingSchedule.terminal_state` default fallback (2 tests)
- `test_terminal_state_default_success_path_for_converging_subclass`: a custom subclass that overrides only `at` (and clamps past-the-end) gets a working `terminal_state()` for free via the base default probing `at(10**9)`.
- `test_terminal_state_default_raise_path_for_nonconverging_subclass`: a subclass whose `at` never returns `is_terminal_state=True` causes the base default to raise `NotImplementedError`.

## Test plan

- [x] `scripts/python -m pytest tests/test_output_transform.py tests/test_acquisition_target.py tests/test_tempering.py -q` passes (44 passed, +10 new tests).
- [x] Full suite still green: `scripts/python -m pytest -q` -> 334 passed (was 324; +10 new tests).
- [x] No source-code changes; tests only.