### PR TITLE
test(benchmarks): regression suite anchoring final MMD per benchmark

### DIFF
--- a/tests/test_benchmark_regression.py
+++ b/tests/test_benchmark_regression.py
@@ -1,0 +1,242 @@
+"""Regression suite anchoring `final_metrics['mmd2']` per `BenchmarkProblem`.
+
+Each `BenchmarkProblem` factory in `sabi.problems.benchmarks` defines a
+named, frozen inference target (posteriordb invariant). This module
+runs a canonical `Algorithm` configuration against every shipped
+benchmark and asserts the achieved final MMD² is at-or-below a
+per-benchmark cap committed below. Drift in the loop, acquisitions,
+emulator, surrogate-distribution path, or final-metric pipeline that
+degrades end-to-end quality should surface here.
+
+Configuration choices
+---------------------
+
+- **Inline `Algorithm(...)` construction.** YAML configs under
+  `configs/regression/` would align with the Hydra runner story but
+  add plumbing that isn't needed yet — the canonical config is
+  intentionally minimal (TinyGP + EI on a candidate set) and lives
+  in one place here. We can lift to YAML when the runner gains a
+  programmatic build entrypoint other tests need.
+- **Tolerances** were pinned by running the suite once at `seed=0`
+  on the branch implementing this test (with x64 active — see
+  `tests/conftest.py`), then padded by ~20-30 % over the achieved
+  value to absorb seed-dependent variance. The achieved value on the
+  pinning run is recorded next to each cap below. Probing under
+  float32 gives different mmd2 values; if you re-pin, do it under
+  the same x64 config the test runs in.
+- **Skip gate.** The full parametrized run takes ~4 min wall-time on
+  a laptop CPU (mostly JIT warm-up and TinyGP refits), well over the
+  30 s budget for default `pytest` runs. The parametrized regression
+  test is therefore gated behind ``SABI_REGRESSION=1`` and skipped
+  on a bare ``pytest`` invocation. The cheap drift check
+  (``test_regression_specs_cover_every_benchmark_factory``) runs
+  unconditionally — it costs nothing and surfaces "added a benchmark
+  but forgot to pin its cap" in the default suite. CI can opt into
+  the heavy run by exporting ``SABI_REGRESSION=1``.
+
+Seed: every test uses `jax.random.key(0)` for determinism.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import jax
+import pytest
+
+from sabi.acquisitions.ei import ExpectedImprovement
+from sabi.acquisitions.optim import CandidateSetOptimizer
+from sabi.algorithms import Algorithm, run
+from sabi.emulators import TinyGPEmulator
+from sabi.metrics.mmd import MMD
+from sabi.problems.base import BenchmarkProblem
+from sabi.problems.benchmarks import (
+    banana_2d,
+    banana_10d,
+    gaussian_2d,
+    gaussian_10d,
+    neals_funnel_3d,
+)
+
+
+# ---------------------------------------------------------------------------
+# Skip gate — opt-in via SABI_REGRESSION=1.
+# ---------------------------------------------------------------------------
+#
+# Applied per-test (rather than module-level) so the trivial
+# `test_regression_specs_cover_every_benchmark_factory` drift check
+# still runs on default `pytest`. Only the heavy parametrized loop is
+# gated.
+
+requires_regression = pytest.mark.skipif(
+    os.environ.get("SABI_REGRESSION") != "1",
+    reason=(
+        "benchmark regression suite is opt-in (set SABI_REGRESSION=1); "
+        "full suite takes ~4 minutes on a laptop CPU."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonical algorithm configuration.
+# ---------------------------------------------------------------------------
+
+
+def _algorithm(
+    input_shape: tuple[int, ...],
+    n_initial: int,
+    n_rounds: int,
+) -> Algorithm:
+    """Canonical regression config: TinyGP + EI on a 512-candidate set.
+
+    `n_initial` and `n_rounds` are tuned per benchmark to give the
+    surrogate enough data to be meaningful at the benchmark's
+    dimension, while keeping the per-test runtime in the 20-90 s
+    range. The choice is part of the benchmark's regression identity:
+    pinning a different budget is an explicit decision, not a silent
+    one.
+    """
+    return Algorithm(
+        emulator_factory=lambda: TinyGPEmulator(input_shape=input_shape),
+        acquisition=ExpectedImprovement(
+            optimizer=CandidateSetOptimizer(n_candidates=512)
+        ),
+        n_initial=n_initial,
+        n_rounds=n_rounds,
+        q=1,
+        metrics=(MMD(n_estimate_samples=512, n_reference_samples=512),),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-benchmark regression specifications.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _RegressionSpec:
+    """Per-benchmark regression configuration + cap.
+
+    Attributes:
+        factory: zero-arg `BenchmarkProblem` factory.
+        n_initial: initial-design size for the regression run. Scales
+            with input dimension so the GP starts from non-degenerate
+            data.
+        n_rounds: total round count (round 0 + acquisition rounds).
+        mmd2_cap: maximum admissible final MMD² at ``seed=0``.
+        achieved: MMD² observed on the pinning run — recorded for
+            review when a future change pushes the cap.
+    """
+
+    factory: Callable[[], BenchmarkProblem]
+    n_initial: int
+    n_rounds: int
+    mmd2_cap: float
+    achieved: float
+
+
+# Caps were set from an initial seed=0 run on the branch implementing
+# this test, with `tests/conftest.py`'s `jax_enable_x64=True` active.
+# Each cap leaves ~20-30 % headroom over the achieved value so that
+# small seed-stable numerics shifts (e.g. JIT-cache state, BLAS
+# threading) don't flake the suite. A regression that pushes any
+# benchmark over its cap is surfacing real degradation, not noise.
+#
+# `gaussian_2d`'s cap is held at 0.05 in absolute terms even though
+# the achieved MMD² is ~0.002: the unbiased U-statistic estimator can
+# wander near zero by O(1/sqrt(n)), and a multiplicative-headroom cap
+# would flake on noise alone. The other benchmarks all sit far enough
+# from zero that ~25 % headroom is the right tolerance shape.
+_SPECS: dict[str, _RegressionSpec] = {
+    "gaussian_2d": _RegressionSpec(
+        factory=gaussian_2d,
+        n_initial=16,
+        n_rounds=8,
+        mmd2_cap=0.05,
+        achieved=0.0018,
+    ),
+    "banana_2d": _RegressionSpec(
+        factory=banana_2d,
+        n_initial=16,
+        n_rounds=8,
+        mmd2_cap=0.60,
+        achieved=0.4595,
+    ),
+    "neals_funnel_3d": _RegressionSpec(
+        factory=neals_funnel_3d,
+        n_initial=24,
+        n_rounds=8,
+        mmd2_cap=0.75,
+        achieved=0.5936,
+    ),
+    "gaussian_10d": _RegressionSpec(
+        factory=gaussian_10d,
+        n_initial=32,
+        n_rounds=12,
+        mmd2_cap=0.45,
+        achieved=0.3306,
+    ),
+    "banana_10d": _RegressionSpec(
+        factory=banana_10d,
+        n_initial=32,
+        n_rounds=12,
+        mmd2_cap=0.85,
+        achieved=0.6841,
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Parameterized regression test.
+# ---------------------------------------------------------------------------
+
+
+@requires_regression
+@pytest.mark.parametrize("benchmark_name", sorted(_SPECS))
+def test_benchmark_regression_mmd2_below_cap(benchmark_name: str) -> None:
+    """Run the canonical config against `benchmark_name`, assert MMD² ≤ cap.
+
+    Anchors `final_metrics['mmd2']` for the named `BenchmarkProblem`
+    against a per-benchmark cap committed in `_SPECS`. The cap is the
+    pinned regression contract — bumping it is a deliberate choice
+    that should be explained in the diff.
+
+    Cross-test, the suite enforces the posteriordb-style invariant
+    that a benchmark name pins one inference target up to a
+    normalizing constant: changing the target distribution behind a
+    name (without renaming) is what these caps catch.
+    """
+    spec = _SPECS[benchmark_name]
+    problem = spec.factory()
+    algorithm = _algorithm(
+        input_shape=problem.input_shape,
+        n_initial=spec.n_initial,
+        n_rounds=spec.n_rounds,
+    )
+    result = run(problem, algorithm, jax.random.key(0))
+
+    mmd2 = float(result.final_metrics["mmd2"])
+    assert mmd2 <= spec.mmd2_cap, (
+        f"{benchmark_name}: final MMD² = {mmd2:.4f} exceeds cap "
+        f"{spec.mmd2_cap:.4f} (pinned achieved = {spec.achieved:.4f}). "
+        f"This is a regression — investigate before bumping the cap."
+    )
+
+
+def test_regression_specs_cover_every_benchmark_factory() -> None:
+    """Every public `BenchmarkProblem` factory must have a regression spec.
+
+    The five-name set is the posteriordb-style identity manifest. If a
+    new factory ships in `sabi.problems.benchmarks` it should land
+    with its own cap; this test catches the drift.
+    """
+    expected = {
+        "gaussian_2d",
+        "gaussian_10d",
+        "banana_2d",
+        "banana_10d",
+        "neals_funnel_3d",
+    }
+    assert set(_SPECS) == expected


### PR DESCRIPTION
Closes #32.

## Summary

Adds hand-computed Cholesky / alpha / `predict_latent` pinning for
`_TinyGPCache.build` and `append_rows`. The existing equivalence test
(`test_tinygp_condition_on_partition_then_condition_matches_full_fit`)
catches drift between the build path and the rank-update path, but
can't catch bugs they share — e.g. a sign flip in the Schur complement,
a transpose in `L_22`, or an off-by-one in residual indexing. Pinning
to values derived from an independent reference path (numpy + scipy on
a hand-built kernel matrix, not the cache's own `jnp.linalg.cholesky`)
closes that blind spot.

## Setup

- Kernel: `Matern52(scale=1.0)`, `noise=0`, `jitter=0`.
- Dataset: 1-D inputs `X = [[0.0], [1.0], [2.0]]`, targets `Y = [0.5, -1.0, 2.0]`.
- Test point: `Xt = [[0.5]]`.
- Tolerance: `atol=1e-10` (the float64 path is well within this).

## Hand-computed values pinned

Closed-form Matern52 with scale 1: `k(d) = (1 + sqrt(5) d + (5/3) d^2) exp(-sqrt(5) d)`.

| quantity | value |
|---|---|
| `k(0.5)` | `0.8286491424181253` |
| `k(1)` | `0.5239941088318203` |
| `k(1.5)` | `0.2831632713397992` |
| `k(2)` | `0.13866021913850426` |

`L_sigma` (full 3-point fit):

```
[[1.0,                  0.0,                 0.0              ],
 [0.5239941088318203,   0.8517218876543836,  0.0              ],
 [0.13866021913850426,  0.5299112038988257,  0.8366405797061  ]]
```

`alpha = L_sigma^{-1} Y`:

```
[0.5, -1.4817008611712585, 3.2461248515413543]
```

`predict_latent([[0.5]])`: mean = `[-0.5711870801337865]`,
var = `[0.09036633090275048]`.

For `append_rows`, starting from the 2-point partial fit `X = [[0], [1]]`,
`Y = [0.5, -1]` (`L_partial = [[1, 0], [0.5239941, 0.8517219]]`,
`alpha_partial = [0.5, -1.4817009]`) and appending `X_new = [[2]]`,
`Y_new = [2]`, the augmented cache must equal the full 3-point values
above — pinned independently of the rank-update math itself.

## Test plan

- [x] `scripts/python -m pytest tests/test_gp_emulator.py -q` (16 passed)
- [x] `scripts/python -m pytest -q` (326 passed)
- [x] Reference values regenerated independently (numpy.linalg.cholesky +
  scipy.linalg.solve_triangular) and audited against the inline derivation.
