### PR TITLE
feat: input validation in pointwise optimizers and MMD

### DIFF
--- a/src/sabi/acquisitions/optim.py
+++ b/src/sabi/acquisitions/optim.py
@@ -92,6 +92,12 @@ class CandidateSetOptimizer(PointwiseOptimizer):
     candidate_sampler: BatchSampler = field(default_factory=PriorSampler)
 
     def optimize(self, acq, state, q, key):
+        if q > self.n_candidates:
+            raise ValueError(
+                f"q ({q}) exceeds n_candidates ({self.n_candidates}); "
+                f"cannot return more picks than candidates scored. Increase "
+                f"`n_candidates` (or decrease `q`)."
+            )
         key_cand, _ = jax.random.split(key)
         candidates = self.candidate_sampler.sample(
             state.problem, key_cand, self.n_candidates
@@ -140,6 +146,12 @@ class ContinuousMultiStartOptimizer(PointwiseOptimizer):
     seed_sampler: BatchSampler = field(default_factory=PriorSampler)
 
     def optimize(self, acq, state, q, key):
+        if q > self.n_starts:
+            raise ValueError(
+                f"q ({q}) exceeds n_starts ({self.n_starts}); cannot return "
+                f"more picks than BFGS seeds. Increase `n_starts` (or "
+                f"decrease `q`)."
+            )
         if self.n_seeding_candidates < self.n_starts:
             raise ValueError(
                 f"n_seeding_candidates ({self.n_seeding_candidates}) must be "

--- a/src/sabi/metrics/mmd.py
+++ b/src/sabi/metrics/mmd.py
@@ -82,6 +82,12 @@ def mmd2_unbiased(X: Array, Y: Array, bandwidth: float | Array | None = None) ->
     m, n = X.shape[0], Y.shape[0]
     if m < 2 or n < 2:
         raise ValueError(f"Unbiased MMD² needs m,n ≥ 2, got m={m}, n={n}.")
+    if bandwidth is not None and float(bandwidth) <= 0.0:
+        raise ValueError(
+            f"bandwidth must be positive; got {bandwidth}. The RBF kernel "
+            f"k(x, y) = exp(-||x - y||² / (2 h²)) is only well-defined for "
+            f"h > 0."
+        )
 
     h = median_heuristic_bandwidth(X, Y) if bandwidth is None else jnp.asarray(bandwidth)
     inv_2h2 = 1.0 / (2.0 * h * h)
@@ -119,6 +125,14 @@ class MMD(Metric):
 
     requires: ClassVar[tuple[type, ...]] = (SupportsSampling,)
     keys: ClassVar[tuple[str, ...]] = ("mmd", "mmd2")
+
+    def __post_init__(self) -> None:
+        if self.bandwidth is not None and self.bandwidth <= 0.0:
+            raise ValueError(
+                f"bandwidth must be positive; got {self.bandwidth}. The RBF "
+                f"kernel k(x, y) = exp(-||x - y||² / (2 h²)) is only "
+                f"well-defined for h > 0."
+            )
 
     def __call__(
         self,

--- a/tests/test_mmd.py
+++ b/tests/test_mmd.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from sabi.metrics.mmd import median_heuristic_bandwidth, mmd2_unbiased, mmd_rbf
+from sabi.metrics.mmd import MMD, median_heuristic_bandwidth, mmd2_unbiased, mmd_rbf
 
 
 def test_mmd2_small_for_same_distribution():
@@ -65,6 +65,32 @@ def test_mmd2_unbiased_on_independent_halves_is_near_zero():
     X1, X2 = X_full[:500], X_full[500:]
     mmd2 = float(mmd2_unbiased(X1, X2))
     assert abs(mmd2) < 5e-3
+
+
+def test_mmd2_unbiased_rejects_zero_bandwidth():
+    """h = 0 produces inf in `1 / (2 h²)`; require an explicit error."""
+    X = jax.random.normal(jax.random.key(0), shape=(20, 2))
+    Y = jax.random.normal(jax.random.key(1), shape=(20, 2))
+    with pytest.raises(ValueError, match="bandwidth"):
+        mmd2_unbiased(X, Y, bandwidth=0.0)
+
+
+def test_mmd2_unbiased_rejects_negative_bandwidth():
+    """Negative h produces a negative `1 / (2 h²)` only via sign of h
+    (h² is positive), but a negative bandwidth has no kernel-theoretic
+    meaning; require an explicit error."""
+    X = jax.random.normal(jax.random.key(0), shape=(20, 2))
+    Y = jax.random.normal(jax.random.key(1), shape=(20, 2))
+    with pytest.raises(ValueError, match="bandwidth"):
+        mmd2_unbiased(X, Y, bandwidth=-1.0)
+
+
+def test_mmd_dataclass_rejects_non_positive_bandwidth():
+    """`MMD(bandwidth=...)` should validate eagerly in `__post_init__`."""
+    with pytest.raises(ValueError, match="bandwidth"):
+        MMD(bandwidth=-1.0)
+    with pytest.raises(ValueError, match="bandwidth"):
+        MMD(bandwidth=0.0)
 
 
 def test_mmd_rbf_clamps_negative_unbiased_to_zero():

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -158,6 +158,28 @@ def test_greedy_multi_point_with_constant_liar_min():
     assert not jnp.allclose(batch[0], batch[1], atol=1e-6)
 
 
+def test_candidate_set_optimizer_raises_when_q_exceeds_n_candidates():
+    """q > n_candidates would silently return < q rows; require a clear
+    `ValueError` instead, with `n_candidates` in the message."""
+    state = _state()
+    optimizer = CandidateSetOptimizer(n_candidates=4)
+    acq = ExpectedImprovement(optimizer=optimizer)
+    with pytest.raises(ValueError, match="n_candidates"):
+        optimizer.optimize(acq, state, q=8, key=jax.random.key(0))
+
+
+def test_continuous_multistart_raises_when_q_exceeds_n_starts():
+    """q > n_starts would silently return < q rows; require a clear
+    `ValueError` instead, with `n_starts` in the message."""
+    state = _state()
+    optimizer = ContinuousMultiStartOptimizer(
+        n_starts=2, n_seeding_candidates=16, bfgs_max_steps=10
+    )
+    acq = _ConcaveScore(target=jnp.zeros(2), optimizer=optimizer)
+    with pytest.raises(ValueError, match="n_starts"):
+        optimizer.optimize(acq, state, q=4, key=jax.random.key(0))
+
+
 def test_continuous_multistart_finds_higher_score_than_candidate_set():
     """At matched cost, continuous-multistart should match-or-beat
     candidate-set. We give continuous a strictly smaller seeding budget,


### PR DESCRIPTION
Closes #34.

## Summary

Two acquisition / metric inputs were previously accepted without validation and produced silent garbage rather than a clear error. This adds eager `ValueError`s at the four affected entry points.

## Validation points added

- `CandidateSetOptimizer.optimize`: rejects `q > n_candidates` (would otherwise silently return `< q` rows from `argsort(-scores)[:q]`). Error message mentions `n_candidates`.
- `ContinuousMultiStartOptimizer.optimize`: rejects `q > n_starts` (same shortfall after BFGS top-q selection). Error message mentions `n_starts`.
- `mmd2_unbiased`: rejects user-supplied `bandwidth <= 0` (would yield `inf` or sign-flipped exponent in `1 / (2 h²)`). The internal `median_heuristic_bandwidth` already guards `med == 0`, so only the user-supplied path is changed.
- `MMD.__post_init__`: same non-positive `bandwidth` check at dataclass construction time, so misconfiguration surfaces before any `__call__`.

## Test plan

- [x] `scripts/python -m pytest tests/test_optim.py tests/test_mmd.py -q` (21 passed; 4 new tests)
- [x] `scripts/python -m pytest -q` full suite (329 passed, no regressions)
- [x] New tests cover each raise path:
  - `test_candidate_set_optimizer_raises_when_q_exceeds_n_candidates`
  - `test_continuous_multistart_raises_when_q_exceeds_n_starts`
  - `test_mmd2_unbiased_rejects_zero_bandwidth` / `..._negative_bandwidth`
  - `test_mmd_dataclass_rejects_non_positive_bandwidth`