### PR TITLE
refactor(acquisitions): drop unused tempering_state fields from AcquisitionState

### DIFF
--- a/src/sabi/acquisitions/base.py
+++ b/src/sabi/acquisitions/base.py
@@ -95,8 +95,9 @@ def resolve_state(
     - `TERMINAL`: returns `schedule.terminal_state()`.
 
     Lives next to `AcquisitionTarget` because it's the canonical
-    consumer of the enum — `target_tempering_state` on
-    `AcquisitionState` is what acquisitions actually see.
+    consumer of the enum. The resolved state is the one at which the
+    loop builds the acquisition's `SurrogateDistribution`; it is not
+    re-exposed on `AcquisitionState` (the SP itself is the carrier).
     """
     if acquisition_target == AcquisitionTarget.CURRENT:
         return current_state
@@ -135,28 +136,28 @@ class AcquisitionState:
     data). Diagnostic / logging code can use ``Y_raw`` to access the
     raw evaluations.
 
+    Note on tempering state. The round's tempering states (current and
+    target) are not re-exposed here: ``surrogate_distribution`` is
+    already built at the target state, and the per-round metric row
+    (`round`, `tempering_state`, `target_tempering_state`, `n_evals`)
+    captures them for ablation logging. Acquisitions that need
+    state-dependent behavior should read the emulator / form via
+    ``surrogate_distribution`` rather than introspect the scalar state.
+
     Attributes:
         problem: the inference problem (provides `prior`, `support`,
             `input_shape`, etc.).
         surrogate_distribution: round's surrogate-posterior random measure
-            built at ``target_tempering_state`` (the state the
-            acquisition optimizes against — see `AcquisitionTarget`).
-            Always set; ``surrogate_distribution.emulator`` may be
-            ``None`` for the weighted-empirical baseline.
+            built at the acquisition's target tempering state (see
+            `AcquisitionTarget`). Always set;
+            ``surrogate_distribution.emulator`` may be ``None`` for the
+            weighted-empirical baseline.
         X: design inputs, shape `(n,) + problem.input_shape`.
         Y_raw: raw target evaluations, shape `(n,) + problem.output_shape`.
-        Y_train: emulator-training targets *at the
-            target_tempering_state*, same shape as Y_raw. Consistent
-            with the SP's emulator. Equal to Y_raw when no
-            target-side tempering is in effect.
-        tempering_state: round's current state from the schedule.
-            Available for acquisitions that want to introspect the
-            round's intermediate distribution independently of the
-            target.
-        target_tempering_state: state at which the
-            ``surrogate_distribution`` is built — the state the
-            acquisition optimizes against. Equal to ``tempering_state``
-            when ``Algorithm.acquisition_target == CURRENT`` (default).
+        Y_train: emulator-training targets at the acquisition's target
+            tempering state, same shape as Y_raw. Consistent with the
+            SP's emulator. Equal to Y_raw when no target-side tempering
+            is in effect.
     """
 
     problem: Problem
@@ -164,8 +165,6 @@ class AcquisitionState:
     X: Array
     Y_raw: Array
     Y_train: Array
-    tempering_state: Any
-    target_tempering_state: Any
 
 
 class Acquisition(ABC):

--- a/src/sabi/algorithms/loop.py
+++ b/src/sabi/algorithms/loop.py
@@ -534,8 +534,6 @@ def _run_acquisition(
         X=X,
         Y_raw=Y_raw,
         Y_train=Y_train_for_acq,
-        tempering_state=round_state.current_intermediate.state,
-        target_tempering_state=round_state.target_intermediate.state,
     )
     x_new = algorithm.acquisition.select_batch(acq_state, algorithm.q, key)
     y_new_raw = problem.target_map(x_new)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,7 @@ def make_acquisition_state(
         seed: PRNG seed for the initial-design draw.
 
     Returns:
-        `AcquisitionState` with `tempering_state=None` and
-        `target_tempering_state=None` (untempered).
+        `AcquisitionState` populated from the fitted SP / design.
     """
     from sabi.acquisitions.base import AcquisitionState
     from sabi.emulators import TinyGPEmulator
@@ -59,6 +58,4 @@ def make_acquisition_state(
         X=X,
         Y_raw=Y,
         Y_train=Y,
-        tempering_state=None,
-        target_tempering_state=None,
     )

--- a/tests/test_acquisition_target.py
+++ b/tests/test_acquisition_target.py
@@ -5,8 +5,10 @@ Verifies:
   no-acquisition-target loop (i.e., behavior preserved).
 - `NEXT` and `TERMINAL` build the SP at a different state than the
   round's current state.
-- `AcquisitionState.target_tempering_state` reflects the resolved
-  state for each acquisition_target value.
+- Per-round metric rows reflect the resolved
+  `(tempering_state, target_tempering_state)` for each
+  `acquisition_target` value (the row is the canonical place these
+  are surfaced — `AcquisitionState` itself does not re-expose them).
 - Schedule's `terminal_state()` returns the correct state for both
   built-in schedules.
 """
@@ -15,10 +17,9 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
-import pytest
 
-from sabi.acquisitions.base import Acquisition, AcquisitionState
 from sabi.acquisitions.base import AcquisitionTarget, resolve_state
+from sabi.acquisitions.random import PriorSampling
 from sabi.algorithms import Algorithm, run
 from sabi.emulators import TinyGPEmulator
 from sabi.problems.benchmarks import gaussian_2d
@@ -120,37 +121,19 @@ def test_resolve_state_terminal_returns_terminal_state():
 
 
 # -------------------------------------------------------------------------
-# Acquisition that captures the target_tempering_state it sees
+# Helpers — read (current, target) tempering states off the per-round
+# metric row, which is where the loop surfaces them.
 # -------------------------------------------------------------------------
 
 
-class _RecordingAcquisition(Acquisition):
-    """Records each round's `(tempering_state, target_tempering_state)`
-    pair, then returns a deterministic batch."""
-
-    def __init__(self):
-        self.calls: list[tuple] = []
-
-    def select_batch(self, state: AcquisitionState, q: int, key):
-        self.calls.append((state.tempering_state, state.target_tempering_state))
-        # Deterministic batch — sample uniformly from support.
-        problem = state.problem
-        lower, upper = problem.support.low, problem.support.high
-        return lower + (upper - lower) * jax.random.uniform(
-            key, shape=(q,) + problem.input_shape
-        )
-
-
-def _algorithm(acquisition_target: AcquisitionTarget, **kwargs):
-    return Algorithm(
-        emulator_factory=lambda: TinyGPEmulator(input_shape=(2,)),
-        acquisition=_RecordingAcquisition(),
-        n_initial=8,
-        n_rounds=3,  # round 0 (initial) + rounds 1, 2 (acquisition).
-        q=1,
-        acquisition_target=acquisition_target,
-        **kwargs,
-    )
+def _acq_round_states(result) -> list[tuple]:
+    """Return ``[(tempering_state, target_tempering_state), ...]`` for
+    each acquisition round (skipping round 0, the initial design)."""
+    return [
+        (row["tempering_state"], row["target_tempering_state"])
+        for row in result.per_round_metrics
+        if row["round"] >= 1
+    ]
 
 
 # -------------------------------------------------------------------------
@@ -163,13 +146,19 @@ def test_current_default_target_state_equals_current():
     target_tempering_state == tempering_state == None for every
     acquisition round."""
     problem = gaussian_2d()
-    alg = _algorithm(AcquisitionTarget.CURRENT)
-    run(problem, alg, jax.random.key(0))
+    alg = Algorithm(
+        emulator_factory=lambda: TinyGPEmulator(input_shape=(2,)),
+        acquisition=PriorSampling(),
+        n_initial=8,
+        n_rounds=3,  # round 0 (initial) + rounds 1, 2 (acquisition).
+        q=1,
+        acquisition_target=AcquisitionTarget.CURRENT,
+    )
+    result = run(problem, alg, jax.random.key(0))
 
-    # n_rounds=3 → round 0 (initial) + rounds 1, 2 (acquisition).
-    acq = alg.acquisition
-    assert len(acq.calls) == 2
-    for current, target in acq.calls:
+    rounds = _acq_round_states(result)
+    assert len(rounds) == 2
+    for current, target in rounds:
         assert current is None
         assert target is None
 
@@ -188,7 +177,7 @@ def test_next_with_fixed_schedule_advances_one_step():
     schedule = FixedSchedule(states=(0.1, 0.5, 1.0))
     alg = Algorithm(
         emulator_factory=lambda: TinyGPEmulator(input_shape=(2,)),
-        acquisition=_RecordingAcquisition(),
+        acquisition=PriorSampling(),
         n_initial=8,
         n_rounds=3,  # round 0 + acquisition rounds 1, 2.
         q=1,
@@ -196,12 +185,12 @@ def test_next_with_fixed_schedule_advances_one_step():
         schedule=schedule,
         acquisition_target=AcquisitionTarget.NEXT,
     )
-    run(problem, alg, jax.random.key(1))
+    result = run(problem, alg, jax.random.key(1))
 
-    calls = alg.acquisition.calls
-    assert len(calls) == 2  # only acquisition rounds 1, 2.
-    assert calls[0] == (0.5, 1.0)
-    assert calls[1] == (1.0, 1.0)
+    rounds = _acq_round_states(result)
+    assert len(rounds) == 2  # only acquisition rounds 1, 2.
+    assert rounds[0] == (0.5, 1.0)
+    assert rounds[1] == (1.0, 1.0)
 
 
 # -------------------------------------------------------------------------
@@ -218,7 +207,7 @@ def test_terminal_target_state_is_terminal_for_every_round():
     schedule = FixedSchedule(states=(0.1, 0.5, 1.0))
     alg = Algorithm(
         emulator_factory=lambda: TinyGPEmulator(input_shape=(2,)),
-        acquisition=_RecordingAcquisition(),
+        acquisition=PriorSampling(),
         n_initial=8,
         n_rounds=3,  # round 0 + acquisition rounds 1, 2.
         q=1,
@@ -226,13 +215,13 @@ def test_terminal_target_state_is_terminal_for_every_round():
         schedule=schedule,
         acquisition_target=AcquisitionTarget.TERMINAL,
     )
-    run(problem, alg, jax.random.key(2))
+    result = run(problem, alg, jax.random.key(2))
 
-    calls = alg.acquisition.calls
-    assert len(calls) == 2
-    for _, target in calls:
+    rounds = _acq_round_states(result)
+    assert len(rounds) == 2
+    for _, target in rounds:
         assert target == 1.0
-    assert [current for current, _ in calls] == [0.5, 1.0]
+    assert [current for current, _ in rounds] == [0.5, 1.0]
 
 
 # -------------------------------------------------------------------------
@@ -245,8 +234,6 @@ def test_default_acquisition_target_preserves_untempered_metrics():
     should yield bit-for-bit identical metrics as the v1.4 baseline.
     Smoke check via runner is exercised by the manual smoke tests; here
     we just confirm the run completes cleanly."""
-    from sabi.acquisitions.random import PriorSampling
-
     problem = gaussian_2d()
     alg = Algorithm(
         emulator_factory=lambda: TinyGPEmulator(input_shape=(2,)),
@@ -269,7 +256,6 @@ def test_via_target_with_next_lookahead_runs_to_completion():
     refit-emulator-at-target-state path. Just verify the run completes
     without error; numerical correctness is covered by the per-scheme
     tests."""
-    from sabi.acquisitions.random import PriorSampling
     from sabi._probpipe_compat import independent_uniform
     from sabi.problems.base import Problem
     from sabi.problems.forms import LogLikPlusPrior
@@ -309,23 +295,3 @@ def test_via_target_with_next_lookahead_runs_to_completion():
     # Acquisition rounds 1, 2 follow.
     assert result.per_round_metrics[1]["target_tempering_state"] == 1.0
     assert result.per_round_metrics[2]["target_tempering_state"] == 1.0  # clamped
-
-
-# -------------------------------------------------------------------------
-# AcquisitionState convenience
-# -------------------------------------------------------------------------
-
-
-def test_acquisition_state_carries_target_tempering_state():
-    """Smoke check the AcquisitionState constructor accepts the new field."""
-    state = AcquisitionState(
-        problem=gaussian_2d(),
-        surrogate_distribution=None,  # type: ignore[arg-type]
-        X=jnp.zeros((1, 2)),
-        Y_raw=jnp.zeros((1,)),
-        Y_train=jnp.zeros((1,)),
-        tempering_state=0.3,
-        target_tempering_state=0.6,
-    )
-    assert state.tempering_state == 0.3
-    assert state.target_tempering_state == 0.6

--- a/tests/test_acquisitions.py
+++ b/tests/test_acquisitions.py
@@ -124,8 +124,6 @@ def test_ei_collapses_to_zero_at_zero_variance():
         X=X,
         Y_raw=Y,
         Y_train=Y,
-        tempering_state=None,
-        target_tempering_state=None,
     )
     x = jnp.zeros(problem.input_shape)
     score = float(ExpectedImprovement()._score_single(x, state))
@@ -152,8 +150,6 @@ def test_ei_raises_on_degenerate_surrogate_emulator():
         X=X,
         Y_raw=Y,
         Y_train=Y,
-        tempering_state=None,
-        target_tempering_state=None,
     )
     with pytest.raises(ValueError, match="non-degenerate emulator"):
         ExpectedImprovement().select_batch(state, q=1, key=jax.random.key(0))


### PR DESCRIPTION
## Summary

Closes #30.

`AcquisitionState` previously carried `tempering_state` and `target_tempering_state` alongside `surrogate_distribution` (which is already built at the target state). The audit confirms neither field is read by any acquisition implementation; both are inert ablation-logging metadata that the per-round metric row already captures. This PR removes both fields from the dataclass and migrates the only test reads (the enum-dispatch tests in `tests/test_acquisition_target.py`) to source the same information from `result.per_round_metrics`, which is the canonical surface for those values.

## Audit findings

Searched `src/` and `tests/` for `state.tempering_state` / `state.target_tempering_state` and for the field names on `AcquisitionState` constructions. Classifications:

| Reference | File:line | Kind |
|---|---|---|
| `AcquisitionState.tempering_state` write | `src/sabi/algorithms/loop.py:537` (in `_run_acquisition`) | bookkeeping write |
| `AcquisitionState.target_tempering_state` write | `src/sabi/algorithms/loop.py:538` (in `_run_acquisition`) | bookkeeping write |
| `AcquisitionState.tempering_state=None` | `tests/conftest.py:62` | bookkeeping write (fixture) |
| `AcquisitionState.target_tempering_state=None` | `tests/conftest.py:63` | bookkeeping write (fixture) |
| `AcquisitionState(..., tempering_state=None, target_tempering_state=None)` x2 | `tests/test_acquisitions.py:127-128, 155-156` | bookkeeping write (EI tests don't read either) |
| `state.tempering_state`, `state.target_tempering_state` reads | `tests/test_acquisition_target.py:72` (`_RecordingAcquisition.select_batch`) | test read of bookkeeping (same data already on metric row) |
| `AcquisitionState(..., tempering_state=0.3, target_tempering_state=0.6)` + assert | `tests/test_acquisition_target.py:264-268` | smoke test of dataclass shape (obsolete after removal) |

**Genuine consumer reads in production code (`src/sabi/acquisitions/*.py`): zero.** `ei.py`, `fantasize.py`, `optim.py`, and `random.py` all read `state.problem`, `state.X`, `state.Y_train`, `state.surrogate_distribution`, but none reads either tempering field.

`MetricContext.tempering_state` (in `src/sabi/metrics/base.py`) is a separate dataclass and is unaffected.

## Chosen action

Remove both fields from `AcquisitionState`. The metric row built in `_build_round_metrics_row` already carries both states for diagnostics (`row["tempering_state"]`, `row["target_tempering_state"]`); `surrogate_distribution` already encodes the target state implicitly. The dataclass docstring now calls out why the fields are intentionally absent so the next person doesn't add them back.

The two tests in `tests/test_acquisition_target.py` that read the fields (`_RecordingAcquisition`-based `(current, target)` assertions) now use a small `_acq_round_states(result)` helper that pulls the same pair off `result.per_round_metrics` — same coverage of the enum dispatch, no recording stub. The dataclass-shape smoke test is dropped (it was only verifying constructor kwargs that no longer exist).

## Test plan

- [x] `scripts/python -m pytest -q` passes (323 passed, same as `origin/main`).
- [x] `tests/test_acquisition_target.py` still verifies all three `AcquisitionTarget` enum values dispatch correctly, via metric-row assertions.
- [x] `grep -rn "state\.tempering_state\|state\.target_tempering_state" src/ tests/` returns nothing.
- [x] No production-code consumers were relying on the fields.
