### PR TITLE
refactor(surrogate): centralize emulator-None guard via require_emulator helper

### DIFF
--- a/src/sabi/acquisitions/ei.py
+++ b/src/sabi/acquisitions/ei.py
@@ -69,14 +69,9 @@ class ExpectedImprovement(PointwiseScoredAcquisition):
     def _score_single(self, x: Array, state: AcquisitionState) -> Array:
         """Single-point EI at `x` (shape `state.problem.input_shape`).
         Returns scalar."""
-        emulator = state.surrogate_distribution.emulator
-        if emulator is None:
-            raise ValueError(
-                "ExpectedImprovement requires a non-degenerate emulator; "
-                "got `state.surrogate_distribution.emulator=None` (this happens "
-                "with the weighted-empirical baseline). Switch to a real "
-                "emulator or use a sampling acquisition like PriorSampling."
-            )
+        emulator = state.surrogate_distribution.require_emulator(
+            "ExpectedImprovement"
+        )
         # emulator.__call__ expects a leading batch axis.
         pred = emulator(x[None])
         mu = jnp.asarray(mean(pred))[0]
@@ -93,12 +88,9 @@ class ExpectedImprovement(PointwiseScoredAcquisition):
         if self.best_from == "data":
             return jnp.max(state.Y_train)
         if self.best_from == "mean":
-            emulator = state.surrogate_distribution.emulator
-            if emulator is None:
-                raise ValueError(
-                    "ExpectedImprovement(best_from='mean') requires a "
-                    "non-degenerate emulator."
-                )
+            emulator = state.surrogate_distribution.require_emulator(
+                "ExpectedImprovement(best_from='mean')"
+            )
             train_pred = emulator(state.X)
             return jnp.max(jnp.asarray(mean(train_pred)))
         raise ValueError(f"Unknown best_from={self.best_from!r}.")

--- a/src/sabi/acquisitions/fantasize.py
+++ b/src/sabi/acquisitions/fantasize.py
@@ -67,13 +67,7 @@ class KrigingBeliever(FantasyImputer):
     """
 
     def impute(self, x_pending: Array, state: AcquisitionState) -> Array:
-        emulator = state.surrogate_distribution.emulator
-        if emulator is None:
-            raise ValueError(
-                "KrigingBeliever requires a non-degenerate emulator; got "
-                "`state.surrogate_distribution.emulator=None` (the "
-                "weighted-empirical baseline)."
-            )
+        emulator = state.surrogate_distribution.require_emulator("KrigingBeliever")
         pred = emulator(x_pending)
         return jnp.asarray(mean(pred))
 

--- a/src/sabi/acquisitions/optim.py
+++ b/src/sabi/acquisitions/optim.py
@@ -252,12 +252,8 @@ class GreedyMultiPointOptimizer(PointwiseOptimizer):
                 # Mutate the surrogate_distribution copy so downstream
                 # score calls see the new emulator.
                 old_sp = state.surrogate_distribution
-                if old_sp.emulator is None:
-                    raise ValueError(
-                        "GreedyMultiPointOptimizer requires a non-degenerate "
-                        "emulator; got `surrogate_distribution.emulator=None`."
-                    )
-                new_emulator = old_sp.emulator.fit(new_X, new_Y_train)
+                old_emulator = old_sp.require_emulator("GreedyMultiPointOptimizer")
+                new_emulator = old_emulator.fit(new_X, new_Y_train)
                 new_sp = type(old_sp)(
                     emulator=new_emulator,
                     log_density_form=old_sp.log_density_form,

--- a/src/sabi/surrogate/surrogate_distribution.py
+++ b/src/sabi/surrogate/surrogate_distribution.py
@@ -110,6 +110,31 @@ class SurrogateDistribution(NumericRandomMeasure):
     def prior(self) -> Distribution | None:
         return self._prior
 
+    # Helpers -----------------------------------------------------------------
+
+    def require_emulator(self, caller: str) -> Emulator:
+        """Return `self.emulator`, raising `ValueError` if it is `None`.
+
+        Used by code paths (e.g. emulator-touching acquisitions, fantasy
+        imputers) that cannot operate on the degenerate / no-emulator
+        baseline. Centralizes the "...requires a non-degenerate emulator"
+        message so consumers don't each hand-roll their own.
+
+        Args:
+            caller: short name of the caller (typically a class name like
+                ``"ExpectedImprovement"``); included in the error message
+                so users can see who rejected the degenerate surrogate.
+        """
+        if self._emulator is None:
+            raise ValueError(
+                f"{caller} requires a non-degenerate emulator; got "
+                f"`surrogate_distribution.emulator=None` (the no-emulator "
+                f"baseline, e.g. WeightedEmpiricalRandomMeasure). Switch "
+                f"to a real emulator or use a sampling-style acquisition "
+                f"like PriorSampling."
+            )
+        return self._emulator
+
     # Protocol implementation -------------------------------------------------
 
     def _random_unnormalized_log_prob(self) -> RandomFunction:

--- a/tests/test_surrogate_distribution.py
+++ b/tests/test_surrogate_distribution.py
@@ -143,6 +143,23 @@ def test_sp_requires_support():
         )
 
 
+def test_require_emulator_returns_emulator_when_present():
+    """Success path: ``require_emulator`` returns ``self.emulator`` unchanged."""
+    sp = _sp()
+    emulator = sp.require_emulator("TestCaller")
+    assert emulator is sp.emulator
+    assert emulator is not None
+
+
+def test_require_emulator_raises_when_none():
+    """Raise path: ``require_emulator`` raises ``ValueError`` naming the
+    caller and the canonical "non-degenerate emulator" message."""
+    werm = _werm()
+    assert werm.emulator is None
+    with pytest.raises(ValueError, match="MyCaller.*non-degenerate emulator"):
+        werm.require_emulator("MyCaller")
+
+
 def test_sp_input_shape_must_match_emulator_input_shape():
     emulator = TinyGPEmulator(input_shape=(2,)).fit(
         jnp.zeros((4, 2)), jnp.zeros(4)


### PR DESCRIPTION
## Summary

Addresses #28 (leave open since Options 1 and 2 remain).

This is **Option 3** from the issue: status quo + helper. Adds a `SurrogateDistribution.require_emulator(caller)` method that returns `self.emulator` or raises a uniform `ValueError` naming the caller. Replaces five hand-rolled `emulator is None` guards across the acquisitions module.

Options **1** (marker `RequiresEmulator` protocol) and **2** (sibling classes under a common random-measure protocol) are deliberately deferred as separate follow-ups, since Option 2 in particular is a higher-blast-radius architectural decision that should go through review.

## Replaced call sites

The five guards that became `state.surrogate_distribution.require_emulator(...)` calls:

1. `src/sabi/acquisitions/ei.py` — `ExpectedImprovement._score_single`
2. `src/sabi/acquisitions/ei.py` — `ExpectedImprovement._best` (`best_from='mean'` branch)
3. `src/sabi/acquisitions/fantasize.py` — `KrigingBeliever.impute`
4. `src/sabi/acquisitions/optim.py` — `GreedyMultiPointOptimizer.optimize`

(Total of four files, five guard sites — `ei.py` carries two of them.)

## Notes

- Error message preserves the `"requires a non-degenerate emulator"` substring, so existing `pytest.raises(..., match="non-degenerate emulator")` assertions (notably `tests/test_acquisitions.py::test_ei_raises_on_degenerate_surrogate_emulator`) keep passing unchanged.
- Helper is added to `SurrogateDistribution` (the base class), so `WeightedEmpiricalRandomMeasure` inherits it; the raise path triggers naturally for the no-emulator baseline.

## Test plan

- [x] `scripts/python -m pytest -q` — full suite passes (326 passed, up from 323 + the new `require_emulator` tests).
- [x] `tests/test_acquisitions.py::test_ei_raises_on_degenerate_surrogate_emulator` still passes with `match="non-degenerate emulator"`.
- [x] New tests in `tests/test_surrogate_distribution.py`:
  - `test_require_emulator_returns_emulator_when_present` — success path returns the emulator object identity.
  - `test_require_emulator_raises_when_none` — raise path includes both the caller name and the canonical error substring.