### PR TITLE
Sibling refactor: SurrogateDistribution abstract base + EmulatedDistribution

### DIFF
--- a/src/sabi/acquisitions/base.py
+++ b/src/sabi/acquisitions/base.py
@@ -113,13 +113,14 @@ def resolve_state(
 class AcquisitionState:
     """Per-round bundle passed to acquisitions. All fields are read-only.
 
-    The round's `SurrogateDistribution` carries the emulator fit on the
-    current design data plus the log-density form for the round.
-    Acquisitions that need a real (non-degenerate) emulator should check
-    ``state.surrogate_distribution.emulator is None`` — this is the case
-    when the loop is running the weighted-empirical baseline (a
-    `WeightedEmpiricalRandomMeasure`, which is a `SurrogateDistribution`
-    subclass with ``emulator=None``).
+    The round's `SurrogateDistribution` is one of two concrete subtypes:
+    `EmulatedDistribution` (emulator-backed; carries the round's fitted
+    emulator and log-density form) or `WeightedEmpiricalRandomMeasure`
+    (the no-emulator baseline; sibling under the abstract base).
+    Acquisitions that need a real emulator narrow
+    ``state.surrogate_distribution`` to `EmulatedDistribution` via
+    ``isinstance`` and raise if the runtime type is the no-emulator
+    baseline.
 
     Two `Y` arrays are exposed:
 

--- a/src/sabi/acquisitions/ei.py
+++ b/src/sabi/acquisitions/ei.py
@@ -41,6 +41,7 @@ from probpipe import mean, variance
 
 from sabi.acquisitions.base import AcquisitionState, PointwiseScoredAcquisition
 from sabi.acquisitions.optim import CandidateSetOptimizer, PointwiseOptimizer
+from sabi.surrogate.surrogate_distribution import EmulatedDistribution
 
 
 @dataclass(frozen=True)
@@ -69,11 +70,17 @@ class ExpectedImprovement(PointwiseScoredAcquisition):
     def _score_single(self, x: Array, state: AcquisitionState) -> Array:
         """Single-point EI at `x` (shape `state.problem.input_shape`).
         Returns scalar."""
-        emulator = state.surrogate_distribution.require_emulator(
-            "ExpectedImprovement"
-        )
+        surrogate_distribution = state.surrogate_distribution
+        if not isinstance(surrogate_distribution, EmulatedDistribution):
+            raise ValueError(
+                f"ExpectedImprovement requires an emulator-backed "
+                f"`EmulatedDistribution`; got "
+                f"{type(surrogate_distribution).__name__} (the no-emulator "
+                f"baseline). Switch to a real emulator or use a "
+                f"sampling-style acquisition like PriorSampling."
+            )
         # emulator.__call__ expects a leading batch axis.
-        pred = emulator(x[None])
+        pred = surrogate_distribution.emulator(x[None])
         mu = jnp.asarray(mean(pred))[0]
         var_ = jnp.asarray(variance(pred))[0]
         std = jnp.sqrt(jnp.maximum(var_, 1e-30))
@@ -88,9 +95,13 @@ class ExpectedImprovement(PointwiseScoredAcquisition):
         if self.best_from == "data":
             return jnp.max(state.Y_train)
         if self.best_from == "mean":
-            emulator = state.surrogate_distribution.require_emulator(
-                "ExpectedImprovement(best_from='mean')"
-            )
-            train_pred = emulator(state.X)
+            surrogate_distribution = state.surrogate_distribution
+            if not isinstance(surrogate_distribution, EmulatedDistribution):
+                raise ValueError(
+                    f"ExpectedImprovement(best_from='mean') requires an "
+                    f"emulator-backed `EmulatedDistribution`; got "
+                    f"{type(surrogate_distribution).__name__}."
+                )
+            train_pred = surrogate_distribution.emulator(state.X)
             return jnp.max(jnp.asarray(mean(train_pred)))
         raise ValueError(f"Unknown best_from={self.best_from!r}.")

--- a/src/sabi/acquisitions/fantasize.py
+++ b/src/sabi/acquisitions/fantasize.py
@@ -29,6 +29,7 @@ from jax import Array
 from probpipe import mean
 
 from sabi.acquisitions.base import AcquisitionState
+from sabi.surrogate.surrogate_distribution import EmulatedDistribution
 
 
 class FantasyImputer(ABC):
@@ -67,8 +68,14 @@ class KrigingBeliever(FantasyImputer):
     """
 
     def impute(self, x_pending: Array, state: AcquisitionState) -> Array:
-        emulator = state.surrogate_distribution.require_emulator("KrigingBeliever")
-        pred = emulator(x_pending)
+        surrogate_distribution = state.surrogate_distribution
+        if not isinstance(surrogate_distribution, EmulatedDistribution):
+            raise ValueError(
+                f"KrigingBeliever requires an emulator-backed "
+                f"`EmulatedDistribution`; got "
+                f"{type(surrogate_distribution).__name__}."
+            )
+        pred = surrogate_distribution.emulator(x_pending)
         return jnp.asarray(mean(pred))
 
 

--- a/src/sabi/acquisitions/optim.py
+++ b/src/sabi/acquisitions/optim.py
@@ -43,6 +43,7 @@ from tensorflow_probability.substrates.jax.bijectors import Bijector, Sigmoid
 from sabi.acquisitions.base import AcquisitionState
 from sabi.acquisitions.fantasize import FantasyImputer, KrigingBeliever
 from sabi.sampling import BatchSampler, PriorSampler
+from sabi.surrogate.surrogate_distribution import EmulatedDistribution
 
 if TYPE_CHECKING:
     from sabi.acquisitions.base import PointwiseScoredAcquisition
@@ -270,22 +271,27 @@ class GreedyMultiPointOptimizer(PointwiseOptimizer):
                 # emulator only consumes Y_train anyway).
                 new_Y_train = jnp.concatenate([state.Y_train, y_pending], axis=0)
                 # Refit the emulator on the augmented training design.
-                # Mutate the surrogate_distribution copy so downstream
+                # Build a fresh `EmulatedDistribution` so downstream
                 # score calls see the new emulator.
-                old_sp = state.surrogate_distribution
-                old_emulator = old_sp.require_emulator("GreedyMultiPointOptimizer")
-                new_emulator = old_emulator.fit(new_X, new_Y_train)
-                new_sp = type(old_sp)(
+                current = state.surrogate_distribution
+                if not isinstance(current, EmulatedDistribution):
+                    raise ValueError(
+                        f"GreedyMultiPointOptimizer requires an emulator-backed "
+                        f"`EmulatedDistribution`; got "
+                        f"{type(current).__name__}."
+                    )
+                new_emulator = current.emulator.fit(new_X, new_Y_train)
+                new_surrogate_distribution = EmulatedDistribution(
                     emulator=new_emulator,
-                    log_density_form=old_sp.log_density_form,
-                    support=old_sp.inner_support,
-                    input_shape=old_sp.inner_event_shape,
-                    prior=old_sp.prior,
-                    name=old_sp.name,
+                    log_density_form=current.log_density_form,
+                    support=current.inner_support,
+                    input_shape=current.inner_event_shape,
+                    prior=current.prior,
+                    name=current.name,
                 )
                 cur_state = replace(
                     state,
-                    surrogate_distribution=new_sp,
+                    surrogate_distribution=new_surrogate_distribution,
                     X=new_X,
                     Y_train=new_Y_train,
                 )

--- a/src/sabi/algorithms/loop.py
+++ b/src/sabi/algorithms/loop.py
@@ -508,12 +508,15 @@ def _run_acquisition(
     round_state: RoundState,
     key: Array,
 ) -> tuple[Array, Array]:
-    """Build the acquisition-state SP, pick the next batch, evaluate the target.
+    """Build the acquisition-state surrogate distribution, pick the
+    next batch, evaluate the target.
 
-    The pre-round `SurrogateDistribution` wraps the acquisition-state
-    emulator + form. The weighted-empirical factory produces an SP with
-    ``emulator=None``; acquisitions that need a real emulator check
-    ``state.surrogate_distribution.emulator is None`` and raise.
+    The pre-round `SurrogateDistribution` is either an
+    `EmulatedDistribution` (carrying the round's emulator + form) or a
+    `WeightedEmpiricalRandomMeasure` (the no-emulator baseline).
+    Acquisitions that need a real emulator narrow to
+    `EmulatedDistribution` via ``isinstance`` and raise if the runtime
+    type is wrong.
 
     Returns ``(x_new, y_new_raw)``: the new batch and its raw target
     evaluations. ``y_new_raw`` is at the *un-transformed* base target —
@@ -692,7 +695,7 @@ def _eval_round(
 
     # Lazy current-state SP+estimate.
     def _current() -> tuple[SurrogateDistribution, Distribution]:
-        sp = _build_surrogate_distribution(
+        surrogate_distribution = _build_surrogate_distribution(
             algorithm.surrogate_distribution_factory,
             emulator=emulator,
             X=X,
@@ -700,14 +703,14 @@ def _eval_round(
             log_density_form=current_intermediate.log_density_form,
             problem=problem,
         )
-        return sp, algorithm.estimator(sp)
+        return surrogate_distribution, algorithm.estimator(surrogate_distribution)
 
     # Lazy terminal-state SP+estimate. Uses `target.log_density_form`
     # (un-tempered base) with the round's emulator + Y_train at the
     # current state — matches the previous "final eval" semantics
     # (preserved for `MetricTarget.TERMINAL` mid-loop).
     def _terminal() -> tuple[SurrogateDistribution, Distribution]:
-        sp = _build_surrogate_distribution(
+        surrogate_distribution = _build_surrogate_distribution(
             algorithm.surrogate_distribution_factory,
             emulator=emulator,
             X=X,
@@ -715,7 +718,7 @@ def _eval_round(
             log_density_form=target.log_density_form,
             problem=problem,
         )
-        return sp, algorithm.estimator(sp)
+        return surrogate_distribution, algorithm.estimator(surrogate_distribution)
 
     return _evaluate_scheduled_metrics(
         scheduled=scheduled_firing,
@@ -745,7 +748,7 @@ def _run_metrics_against_pair(
     tempering_state: Any,
     round_idx: int,
 ) -> dict[str, float]:
-    """Run each metric in `metrics` against a fixed `(sp, estimate, metric_target)`.
+    """Run each metric in `metrics` against a fixed `(surrogate_distribution, estimate, metric_target)`.
 
     Builds a `MetricContext` per metric, invokes the metric under its
     pre-split PRNG key, applies the scheduled metric's suffix, and
@@ -826,11 +829,11 @@ def _evaluate_scheduled_metrics(
             factory = factories[target]
         except KeyError as e:
             raise ValueError(f"Unknown MetricTarget: {target!r}") from e
-        sp, estimate = factory()
+        surrogate_distribution, estimate = factory()
         out = _run_metrics_against_pair(
             metrics=[s for s, _ in pairs],
             keys=[mkey for _, mkey in pairs],
-            surrogate_distribution=sp,
+            surrogate_distribution=surrogate_distribution,
             estimate=estimate,
             metric_target=target,
             problem=problem,

--- a/src/sabi/algorithms/surrogate_distribution_factory.py
+++ b/src/sabi/algorithms/surrogate_distribution_factory.py
@@ -5,13 +5,18 @@ A `SurrogateDistributionFactory` packages the per-round
 `SurrogateDistribution`. Two factories ship today:
 
 - `emulator_pushforward_factory` (default): wraps a fitted emulator and
-  the round's log-density form into a `SurrogateDistribution` that
+  the round's log-density form into an `EmulatedDistribution` that
   pushes the emulator's predictive through the form via
   `pushforward_marginal`.
 - `weighted_empirical_factory`: the no-emulator baseline. Applies the
   form to `(X, Y)` directly to compute log-weights, returning a
-  `WeightedEmpiricalRandomMeasure` (a `SurrogateDistribution` subclass
-  with `emulator=None`).
+  `WeightedEmpiricalRandomMeasure` (a sibling of `EmulatedDistribution`
+  under the abstract `SurrogateDistribution` base).
+
+Both factories share a single signature including `emulator`. The
+weighted-empirical factory ignores its `emulator` argument; the loop
+always has one to hand, so requiring the kwarg keeps the protocol
+uniform across factories.
 
 The `Algorithm` carries its choice of factory via
 `Algorithm.surrogate_distribution_factory`.
@@ -26,7 +31,10 @@ from probpipe.core._distribution_base import Distribution
 from probpipe.core.constraints import Constraint
 
 from sabi.emulators.base import Emulator
-from sabi.surrogate.surrogate_distribution import SurrogateDistribution
+from sabi.surrogate.surrogate_distribution import (
+    EmulatedDistribution,
+    SurrogateDistribution,
+)
 from sabi.surrogate.weighted_empirical import WeightedEmpiricalRandomMeasure
 from sabi.problems.forms import LogDensityForm
 
@@ -35,12 +43,12 @@ class SurrogateDistributionFactory(Protocol):
     """Builds the round's `SurrogateDistribution` from the emulator state and
     the math primitives (support, input_shape, prior, log_density_form).
 
-    Returns a `SurrogateDistribution`. The default factory
-    (`emulator_pushforward_factory`) builds an SP that pushes the
-    fitted emulator's predictive through the form. The
-    `weighted_empirical_factory` builds the no-emulator baseline
-    (`WeightedEmpiricalRandomMeasure`, a `SurrogateDistribution` subclass
-    with ``emulator=None``).
+    Returns a `SurrogateDistribution` (the abstract base shared by
+    `EmulatedDistribution` and `WeightedEmpiricalRandomMeasure`). The
+    default factory (`emulator_pushforward_factory`) builds an
+    `EmulatedDistribution` that pushes the fitted emulator's predictive
+    through the form. `weighted_empirical_factory` builds the
+    no-emulator baseline (`WeightedEmpiricalRandomMeasure`).
 
     `X` and `Y` are the design set; `log_density_form` is the form for
     the round (possibly tempered). `emulator` may be ignored by
@@ -72,24 +80,24 @@ def emulator_pushforward_factory(
     input_shape: tuple[int, ...],
     prior: Distribution | None,
     problem_name: str | None = None,
-) -> SurrogateDistribution:
-    """Default factory: build the `SurrogateDistribution` that pushes the
+) -> EmulatedDistribution:
+    """Default factory: build the `EmulatedDistribution` that pushes the
     fitted emulator's predictive distribution through ``log_density_form``.
 
-    The pushforward itself lives inside `SurrogateDistribution`
+    The pushforward itself lives inside `EmulatedDistribution`
     (`_random_unnormalized_log_prob` / `pushforward_marginal`); this
     factory just wires the round's emulator, form, and problem-side
-    primitives into a fresh `SurrogateDistribution` instance.
+    primitives into a fresh `EmulatedDistribution` instance.
 
     Emulator-agnostic — works for any `Emulator` subclass, not just GPs.
     """
-    return SurrogateDistribution(
+    return EmulatedDistribution(
         emulator=emulator,
         log_density_form=log_density_form,
         support=support,
         input_shape=input_shape,
         prior=prior,
-        name=f"surrogate_distribution_{problem_name}" if problem_name else None,
+        name=f"emulated_distribution_{problem_name}" if problem_name else None,
     )
 
 

--- a/src/sabi/metrics/base.py
+++ b/src/sabi/metrics/base.py
@@ -68,11 +68,10 @@ class MetricContext:
             Built from `surrogate_distribution` via
             `algorithm.estimator`.
         surrogate_distribution: the round's `SurrogateDistribution`
-            (carries the fitted emulator and the round's
-            log-density form). Available for metrics that need to
-            inspect the surrogate directly. May have
-            `emulator=None` when the loop is running the
-            weighted-empirical baseline.
+            — either an `EmulatedDistribution` (emulator-backed) or
+            a `WeightedEmpiricalRandomMeasure` (no-emulator baseline).
+            Metrics that need to inspect the emulator narrow to
+            `EmulatedDistribution` via `isinstance`.
         problem: the inference problem (provides `prior`,
             `reference_distribution`, `support`, `input_shape`,
             etc.).

--- a/src/sabi/surrogate/__init__.py
+++ b/src/sabi/surrogate/__init__.py
@@ -1,8 +1,12 @@
 from sabi.surrogate.estimators import expected_target
-from sabi.surrogate.surrogate_distribution import SurrogateDistribution
+from sabi.surrogate.surrogate_distribution import (
+    EmulatedDistribution,
+    SurrogateDistribution,
+)
 from sabi.surrogate.weighted_empirical import WeightedEmpiricalRandomMeasure
 
 __all__ = [
+    "EmulatedDistribution",
     "SurrogateDistribution",
     "WeightedEmpiricalRandomMeasure",
     "expected_target",

--- a/src/sabi/surrogate/estimators.py
+++ b/src/sabi/surrogate/estimators.py
@@ -1,8 +1,8 @@
 """Free-function deterministic posterior estimators.
 
-Each estimator is a function `(sp) -> Distribution[Array]` that returns a
-concrete deterministic posterior approximation. Type dispatch on `sp`
-matches ProbPipe's op-dispatch style.
+Each estimator is a function `(surrogate_distribution) -> Distribution[Array]`
+that returns a concrete deterministic posterior approximation. Type
+dispatch on the runtime type matches ProbPipe's op-dispatch style.
 
 For Dirac surrogate posteriors (`WeightedEmpiricalRandomMeasure`), all
 sensible deterministic estimators coincide and reduce to the underlying
@@ -10,16 +10,17 @@ empirical — there's nothing random to estimate.
 
 Currently shipped:
 
-- `expected_target(sp)` — plug the surrogate's predictive mean into the
-  log-density form. The expectation of the target map under the
-  surrogate distribution. Biased in the GP-pushforward case (the
-  plug-in is not the same as the unbiased expected posterior
-  `mean(rm)`).
+- `expected_target(surrogate_distribution)` — plug the surrogate's
+  predictive mean into the log-density form. The expectation of the
+  target map under the surrogate distribution. Biased in the
+  emulator-pushforward case (the plug-in is not the same as the
+  unbiased expected posterior `mean(rm)`).
 
-The unbiased expected posterior is exposed via `mean(sp)` (handled by
-ProbPipe's `mean` op via `SupportsMean`). For Dirac SPs this returns
-the inner empirical; for the GP-pushforward case there is no general
-`SupportsMean` implementation today and `mean(gp_sp)` raises.
+The unbiased expected posterior is exposed via
+`mean(surrogate_distribution)` (handled by ProbPipe's `mean` op via
+`SupportsMean`). For the Dirac case this returns the inner empirical;
+for the emulator-pushforward case there is no general `SupportsMean`
+implementation today and `mean(emulated_distribution)` raises.
 
 Future estimators — see `docs/probpipe_issues.md` for the
 partial-pushforward primitive that would generalize their construction.
@@ -37,14 +38,17 @@ from probpipe.core._distribution_base import Distribution
 from probpipe.core._numeric_record_distribution import NumericRecordDistribution
 from probpipe.core.constraints import Constraint
 
-from sabi.surrogate.surrogate_distribution import SurrogateDistribution
+from sabi.surrogate.surrogate_distribution import (
+    EmulatedDistribution,
+    SurrogateDistribution,
+)
 from sabi.surrogate.weighted_empirical import WeightedEmpiricalRandomMeasure
 from sabi.problems.forms import LogDensityForm
 from sabi.emulators.base import Emulator
 
 
 def expected_target(
-    sp,
+    surrogate_distribution: SurrogateDistribution,
     *,
     sampler: str | None = None,
     sampler_kwargs: dict[str, Any] | None = None,
@@ -53,33 +57,35 @@ def expected_target(
     """Return the deterministic posterior obtained by plugging the
     surrogate's predictive mean into the log-density form.
 
-    Type dispatch on `sp`:
+    Type dispatch on the runtime type of ``surrogate_distribution``:
 
-    - `WeightedEmpiricalRandomMeasure` (Dirac): returns the inner
-      empirical (which IS the deterministic target). `sampler` /
-      `sampler_kwargs` are ignored.
-    - `SurrogateDistribution`: returns an `_ExpectedTargetDistribution`
-      whose `_unnormalized_log_prob` is the form composed with the
-      surrogate's predictive mean. Sampling delegates to ProbPipe
-      `condition_on` (auto-dispatched MCMC). `sampler` selects a
-      specific method (e.g. `"tfp_nuts"`); `sampler_kwargs` forwards
-      arguments like `num_results`, `num_warmup`.
+    - :class:`WeightedEmpiricalRandomMeasure` (Dirac): returns the
+      inner empirical (which IS the deterministic target). ``sampler``
+      / ``sampler_kwargs`` are ignored.
+    - :class:`EmulatedDistribution`: returns an
+      ``_ExpectedTargetDistribution`` whose ``_unnormalized_log_prob``
+      is the form composed with the emulator's predictive mean.
+      Sampling delegates to ProbPipe ``condition_on`` (auto-dispatched
+      MCMC). ``sampler`` selects a specific method (e.g.
+      ``"tfp_nuts"``); ``sampler_kwargs`` forwards arguments like
+      ``num_results``, ``num_warmup``.
     """
-    if isinstance(sp, WeightedEmpiricalRandomMeasure):
-        return sp.inner_distribution
-    if isinstance(sp, SurrogateDistribution):
+    if isinstance(surrogate_distribution, WeightedEmpiricalRandomMeasure):
+        return surrogate_distribution.inner_distribution
+    if isinstance(surrogate_distribution, EmulatedDistribution):
         return _ExpectedTargetDistribution(
-            emulator=sp.emulator,
-            log_density_form=sp.log_density_form,
-            prior=sp.prior,
-            input_shape=sp.inner_event_shape,
-            support=sp.inner_support,
+            emulator=surrogate_distribution.emulator,
+            log_density_form=surrogate_distribution.log_density_form,
+            prior=surrogate_distribution.prior,
+            input_shape=surrogate_distribution.inner_event_shape,
+            support=surrogate_distribution.inner_support,
             sampler=sampler,
             sampler_kwargs=sampler_kwargs,
-            name=name or f"expected_target_{sp.name}",
+            name=name or f"expected_target_{surrogate_distribution.name}",
         )
     raise TypeError(
-        f"expected_target: unsupported posterior type {type(sp).__name__}."
+        f"expected_target: unsupported posterior type "
+        f"{type(surrogate_distribution).__name__}."
     )
 
 

--- a/src/sabi/surrogate/surrogate_distribution.py
+++ b/src/sabi/surrogate/surrogate_distribution.py
@@ -1,33 +1,48 @@
-"""`SurrogateDistribution` — random measure induced by an emulator of the
-target map composed with a `LogDensityForm`.
+"""`SurrogateDistribution` and concrete subtypes.
 
-A `SurrogateDistribution` is a ProbPipe `NumericRandomMeasure[Array]`:
-every emulator function realization defines a deterministic posterior,
-and the random measure is the distribution over these. Decoupled from
-`Problem`: takes math primitives directly (`support`, `prior`,
-`log_density_form`, `input_shape`); the loop pulls those from the
-`Problem` per round.
+`SurrogateDistribution` is sabi's abstract base for surrogate posteriors —
+random measures over `Distribution[Array]`s on the parameter space. Two
+concrete realizations live in this package, both inheriting from this base:
 
-`emulator=None` denotes a Dirac surrogate posterior, concretely realized
-by `WeightedEmpiricalRandomMeasure`. The base class raises
-`NotImplementedError` from emulator-touching protocol methods on a
-None emulator; degenerate subclasses opt in by overriding.
+- `EmulatedDistribution` (this module) — emulator-backed; pushes the
+  emulator's predictive through a `LogDensityForm`. Every emulator
+  function realization defines a deterministic posterior; the random
+  measure is the distribution over these.
+- `WeightedEmpiricalRandomMeasure` (in `weighted_empirical.py`) —
+  degenerate / Dirac at a weighted empirical of design points. No
+  emulator, no form.
 
-Protocol opt-ins:
+The two subtypes are **siblings**, not parent/child. Code that needs to
+operate on either uses `SurrogateDistribution` as the type. Code that
+needs an emulator narrows to `EmulatedDistribution` via `isinstance` and
+raises if the runtime type is the no-emulator baseline.
+
+See ``docs/design.md §4.5`` for the architectural framing and
+``docs/notation.md`` for the "emulator" vs. "surrogate" naming
+convention.
+
+Protocol opt-ins
+----------------
+
+`EmulatedDistribution` opts into:
 
 - `SupportsRandomUnnormalizedLogProb`: returns a thin `RandomFunction`
   that pushes the emulator's predictive at `X` through the form via
-  `pushforward_marginal`. Requires a non-None `emulator`.
-- `SupportsSampling`, `SupportsMean`, `SupportsRandomLogProb`: not
-  implemented on the base; degenerate subclasses may implement them.
+  `pushforward_marginal`.
 
-See ``docs/design.md`` §4.5 and ``docs/notation.md`` for the full
-"emulator" vs. "surrogate" naming convention and the architectural
-context.
+It does NOT opt into `SupportsSampling`, `SupportsMean`, or
+`SupportsRandomLogProb` on the base class — function-trajectory
+sampling, unbiased expected-posterior, and normalized random log-prob
+require machinery (MC backends, normalization estimates) deferred to
+later milestones.
+
+`WeightedEmpiricalRandomMeasure` opts into all four protocols via the
+underlying `NumericEmpiricalDistribution` and Dirac shims.
 """
 
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import ClassVar
 
 from jax import Array
@@ -42,23 +57,49 @@ from sabi.problems.forms import LogDensityForm
 
 
 class SurrogateDistribution(NumericRandomMeasure):
-    """Random measure induced by an emulator of the target map composed
-    with a `LogDensityForm`.
+    """Abstract base for sabi's surrogate posteriors.
+
+    Two concrete subtypes:
+
+    - :class:`EmulatedDistribution` — emulator-backed; pushes the
+      emulator's predictive through a :class:`LogDensityForm`.
+    - :class:`WeightedEmpiricalRandomMeasure` — degenerate (Dirac) at
+      a weighted empirical of design points; no emulator, no form.
+
+    Code that needs to operate on either subtype types against this
+    base. Code that needs an emulator narrows to
+    `EmulatedDistribution` via ``isinstance`` and raises if the
+    runtime type is wrong.
+    """
+
+    @property
+    @abstractmethod
+    def inner_support(self) -> Constraint:
+        """Support shared by every inner `Distribution[Array]`'s samples."""
+
+    @property
+    @abstractmethod
+    def inner_event_shape(self) -> tuple[int, ...]:
+        """`event_shape` shared by the inner distributions."""
+
+
+class EmulatedDistribution(SurrogateDistribution):
+    """Surrogate posterior obtained by composing an emulator's predictive
+    distribution with a `LogDensityForm` via pushforward.
+
+    For each emulator function realization, the form defines a
+    deterministic posterior; the random measure is the distribution
+    over these posteriors as the emulator's random function varies.
 
     Args:
         emulator: a fittable `Emulator` (an `ArrayRandomFunction` over
-            the parameter space). Provides the predictive distribution at
-            query points via `__call__(X, joint_inputs, joint_outputs)`.
-            ``None`` denotes a degenerate surrogate posterior — see the
-            module docstring; subclasses must override the relevant
-            protocol methods for this to work.
+            the parameter space). Provides the predictive distribution
+            at query points via `__call__(X, joint_inputs, joint_outputs)`.
         log_density_form: composes the emulator's outputs with the prior
-            into an unnormalized log-posterior. ``None`` is allowed for
-            degenerate subclasses where the form is consumed at
-            construction time (e.g. `WeightedEmpiricalRandomMeasure`).
+            into an unnormalized log-posterior.
         support: `Constraint` over the parameter space.
         input_shape: shape of one parameter-space point. Must equal
-            `emulator.input_shape` when ``emulator is not None``.
+            `emulator.input_shape`.
         prior: optional `Distribution`; required by forms that access it
             (`LogLikPlusPrior`, `ForwardModel`).
         name: optional ProbPipe distribution name.
@@ -66,17 +107,27 @@ class SurrogateDistribution(NumericRandomMeasure):
 
     def __init__(
         self,
-        emulator: Emulator | None,
-        log_density_form: LogDensityForm | None,
+        emulator: Emulator,
+        log_density_form: LogDensityForm,
         *,
         support: Constraint,
         input_shape: tuple[int, ...],
         prior: Distribution | None = None,
         name: str | None = None,
     ):
+        if emulator is None:
+            raise ValueError(
+                "EmulatedDistribution requires a non-None `emulator`. "
+                "Use `WeightedEmpiricalRandomMeasure` for the no-emulator "
+                "baseline."
+            )
+        if log_density_form is None:
+            raise ValueError(
+                "EmulatedDistribution requires a non-None `log_density_form`."
+            )
         if support is None:
-            raise ValueError("SurrogateDistribution requires a non-None `support`.")
-        if emulator is not None and tuple(input_shape) != tuple(emulator.input_shape):
+            raise ValueError("EmulatedDistribution requires a non-None `support`.")
+        if tuple(input_shape) != tuple(emulator.input_shape):
             raise ValueError(
                 f"input_shape={tuple(input_shape)} must match "
                 f"emulator.input_shape={tuple(emulator.input_shape)}."
@@ -99,74 +150,45 @@ class SurrogateDistribution(NumericRandomMeasure):
         return self._input_shape
 
     @property
-    def emulator(self) -> Emulator | None:
+    def emulator(self) -> Emulator:
         return self._emulator
 
     @property
-    def log_density_form(self) -> LogDensityForm | None:
+    def log_density_form(self) -> LogDensityForm:
         return self._log_density_form
 
     @property
     def prior(self) -> Distribution | None:
         return self._prior
 
-    # Helpers -----------------------------------------------------------------
-
-    def require_emulator(self, caller: str) -> Emulator:
-        """Return `self.emulator`, raising `ValueError` if it is `None`.
-
-        Used by code paths (e.g. emulator-touching acquisitions, fantasy
-        imputers) that cannot operate on the degenerate / no-emulator
-        baseline. Centralizes the "...requires a non-degenerate emulator"
-        message so consumers don't each hand-roll their own.
-
-        Args:
-            caller: short name of the caller (typically a class name like
-                ``"ExpectedImprovement"``); included in the error message
-                so users can see who rejected the degenerate surrogate.
-        """
-        if self._emulator is None:
-            raise ValueError(
-                f"{caller} requires a non-degenerate emulator; got "
-                f"`surrogate_distribution.emulator=None` (the no-emulator "
-                f"baseline, e.g. WeightedEmpiricalRandomMeasure). Switch "
-                f"to a real emulator or use a sampling-style acquisition "
-                f"like PriorSampling."
-            )
-        return self._emulator
-
     # Protocol implementation -------------------------------------------------
 
     def _random_unnormalized_log_prob(self) -> RandomFunction:
-        if self._emulator is None:
-            raise NotImplementedError(
-                f"{type(self).__name__}._random_unnormalized_log_prob: "
-                "emulator is None (degenerate SurrogateDistribution); "
-                "subclass must override this method."
-            )
-        return _SurrogateDistributionPushforward(self)
+        return _EmulatedDistributionPushforward(self)
 
 
-class _SurrogateDistributionPushforward(RandomFunction):
-    """The random unnormalized log-density of a `SurrogateDistribution`.
+class _EmulatedDistributionPushforward(RandomFunction):
+    """The random unnormalized log-density of an `EmulatedDistribution`.
 
     `__call__(X)` evaluates the emulator's predictive at `X` (a
-    `Distribution`) and pushes it through the SP's `log_density_form` via
-    `pushforward_marginal`. Joint flags pass through to the emulator
-    (so callers can request joint over inputs / outputs when the
-    emulator supports it).
+    `Distribution`) and pushes it through the surrogate's
+    `log_density_form` via `pushforward_marginal`. Joint flags pass
+    through to the emulator (so callers can request joint over inputs /
+    outputs when the emulator supports it).
     """
 
     _sampling_cost: ClassVar[str] = "low"
     _preferred_orchestration: ClassVar[str | None] = None
 
-    def __init__(self, sp: SurrogateDistribution):
-        self._sp = sp
-        super().__init__(name=f"{sp.name}_random_unnormalized_log_prob")
+    def __init__(self, surrogate_distribution: EmulatedDistribution):
+        self._surrogate_distribution = surrogate_distribution
+        super().__init__(
+            name=f"{surrogate_distribution.name}_random_unnormalized_log_prob"
+        )
 
     @property
     def input_shape(self) -> tuple[int, ...]:
-        return self._sp.inner_event_shape
+        return self._surrogate_distribution.inner_event_shape
 
     @property
     def output_shape(self) -> tuple[int, ...]:
@@ -179,14 +201,14 @@ class _SurrogateDistributionPushforward(RandomFunction):
         joint_inputs: bool = False,
         joint_outputs: bool = False,
     ) -> Distribution:
-        sp = self._sp
+        surrogate_distribution = self._surrogate_distribution
         # The emulator validates X against its own input_shape contract.
-        input_dist = sp.emulator(
+        input_dist = surrogate_distribution.emulator(
             X, joint_inputs=joint_inputs, joint_outputs=joint_outputs
         )
         return pushforward_marginal(
             input_dist,
-            sp.log_density_form,
+            surrogate_distribution.log_density_form,
             X=X,
-            prior=sp.prior,
+            prior=surrogate_distribution.prior,
         )

--- a/src/sabi/surrogate/weighted_empirical.py
+++ b/src/sabi/surrogate/weighted_empirical.py
@@ -4,17 +4,16 @@ The simplest non-trivial random measure: zero variance over inner-distribution
 draws, with the inner distribution being a `NumericEmpiricalDistribution`
 weighted by `softmax(log_weights)`.
 
-Conceptually this is a `SurrogateDistribution` whose underlying emulator is
-degenerate — there's no random function, the design points carry the
-posterior structure directly. Implemented as a `SurrogateDistribution`
-subclass with `emulator=None`, so the algorithm loop and acquisitions
-see one unified type.
+Sibling of `EmulatedDistribution` under `SurrogateDistribution` (per
+``docs/design.md §4.5``): both extend the abstract base
+`SurrogateDistribution`, neither inherits from the other. The design
+points carry the posterior structure directly — there is no underlying
+emulator and no carried log-density form (the form's role ends at
+construction, when `log_weights` is computed from `(X, Y)`).
 
-In sabi this serves as a no-emulator baseline for the loop — the loop's
+In sabi this serves as the no-emulator baseline for the loop. The loop's
 factory applies a `LogDensityForm` to `(X, Y)` to compute `log_weights`,
-then hands the resulting `(X, log_weights)` to this class. The class
-itself does NOT carry the form (the form's role ends once weights are
-computed; `log_density_form` is `None` on the resulting SP).
+then hands the resulting `(X, log_weights)` to this class.
 
 Tracked for promotion to ProbPipe — see `docs/probpipe_issues.md`:
 "`WeightedEmpiricalRandomMeasure` as a ProbPipe primitive".
@@ -43,10 +42,11 @@ class WeightedEmpiricalRandomMeasure(SurrogateDistribution):
 
     A draw from this random measure is always the same
     `NumericEmpiricalDistribution` over `(X, log_weights)`. Implements
-    the full `NumericRandomMeasure` protocol surface via the underlying
-    empirical and Dirac shims. As a `SurrogateDistribution` subclass, it
-    reports `emulator=None` and `log_density_form=None` (the form was
-    consumed at construction time to compute the weights).
+    the full `NumericRandomMeasure` protocol surface (`SupportsMean`,
+    `SupportsSampling`, `SupportsRandomLogProb`,
+    `SupportsRandomUnnormalizedLogProb`) via the underlying empirical
+    and Dirac shims. Sibling of `EmulatedDistribution`; carries no
+    emulator and no form.
 
     Args:
         X: design points, shape `(n,) + input_shape`.
@@ -82,18 +82,28 @@ class WeightedEmpiricalRandomMeasure(SurrogateDistribution):
                 f"log_weights must have shape ({X.shape[0]},), "
                 f"got {tuple(log_weights.shape)}."
             )
+        if support is None:
+            raise ValueError(
+                "WeightedEmpiricalRandomMeasure requires a non-None `support`."
+            )
         self._X = X
         self._log_weights = log_weights
-        # Initialize the SurrogateDistribution base with a degenerate
-        # emulator (None) and no form (consumed into log_weights).
-        super().__init__(
-            emulator=None,
-            log_density_form=None,
-            support=support,
-            input_shape=input_shape,
-            prior=None,
-            name=name or type(self).__name__,
-        )
+        self._support = support
+        self._input_shape = tuple(input_shape)
+        # Direct super-init: the abstract `SurrogateDistribution` takes
+        # only `name`. No bogus `emulator=None, log_density_form=None`
+        # kwargs (those didn't belong on the base in the first place).
+        super().__init__(name=name or type(self).__name__)
+
+    # NumericRandomMeasure abstract properties
+
+    @property
+    def inner_support(self) -> Constraint:
+        return self._support
+
+    @property
+    def inner_event_shape(self) -> tuple[int, ...]:
+        return self._input_shape
 
     @property
     def X(self) -> Array:
@@ -111,7 +121,7 @@ class WeightedEmpiricalRandomMeasure(SurrogateDistribution):
             name=f"{self.name}_empirical",
         )
 
-    # Protocol implementations (overrides of SurrogateDistribution defaults) -----
+    # Protocol implementations -----------------------------------------------
 
     def _mean(self) -> Distribution:
         return self.inner_distribution

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def make_acquisition_state(
     """Build an `AcquisitionState` for tests of acquisitions / optimizers / imputers.
 
     Defaults to the validated `gaussian_2d()` benchmark with a fitted
-    `TinyGPEmulator` and a `SurrogateDistribution` wrapping it. Design
+    `TinyGPEmulator` and an `EmulatedDistribution` wrapping it. Design
     points come from `PriorSampler` — the same path used by acquisition
     candidate sets, so the GP is trained on the same support the
     acquisitions will explore.
@@ -32,20 +32,20 @@ def make_acquisition_state(
         seed: PRNG seed for the initial-design draw.
 
     Returns:
-        `AcquisitionState` populated from the fitted SP / design.
+        `AcquisitionState` populated from the fitted emulator-backed SP.
     """
     from sabi.acquisitions.base import AcquisitionState
     from sabi.emulators import TinyGPEmulator
     from sabi.problems.benchmarks import gaussian_2d
     from sabi.sampling import PriorSampler
-    from sabi.surrogate.surrogate_distribution import SurrogateDistribution
+    from sabi.surrogate.surrogate_distribution import EmulatedDistribution
 
     if problem is None:
         problem = gaussian_2d()
     X = PriorSampler().sample(problem, jax.random.key(seed), n)
     Y = problem.target_map(X)
     emulator = TinyGPEmulator(input_shape=problem.input_shape).fit(X, Y)
-    sp = SurrogateDistribution(
+    surrogate_distribution = EmulatedDistribution(
         emulator=emulator,
         log_density_form=problem.log_density_form,
         support=problem.support,
@@ -54,7 +54,7 @@ def make_acquisition_state(
     )
     return AcquisitionState(
         problem=problem,
-        surrogate_distribution=sp,
+        surrogate_distribution=surrogate_distribution,
         X=X,
         Y_raw=Y,
         Y_train=Y,

--- a/tests/test_acquisitions.py
+++ b/tests/test_acquisitions.py
@@ -9,7 +9,7 @@ from sabi.acquisitions.ei import ExpectedImprovement
 from sabi.acquisitions.optim import CandidateSetOptimizer
 from sabi.acquisitions.random import PriorSampling
 from sabi.emulators.base import Emulator
-from sabi.surrogate.surrogate_distribution import SurrogateDistribution
+from sabi.surrogate.surrogate_distribution import EmulatedDistribution
 from sabi.surrogate.weighted_empirical import WeightedEmpiricalRandomMeasure
 from sabi.problems.benchmarks import gaussian_2d
 from sabi.sampling import PriorSampler
@@ -111,7 +111,7 @@ def test_ei_collapses_to_zero_at_zero_variance():
     X = PriorSampler().sample(problem, jax.random.key(0), 4)
     Y = problem.target_map(X)
     emulator = _ConstantEmulator(loc=0.0, scale=0.0, input_shape=problem.input_shape)
-    sp = SurrogateDistribution(
+    surrogate_distribution = EmulatedDistribution(
         emulator=emulator,
         log_density_form=problem.log_density_form,
         support=problem.support,
@@ -120,7 +120,7 @@ def test_ei_collapses_to_zero_at_zero_variance():
     )
     state = AcquisitionState(
         problem=problem,
-        surrogate_distribution=sp,
+        surrogate_distribution=surrogate_distribution,
         X=X,
         Y_raw=Y,
         Y_train=Y,
@@ -130,15 +130,15 @@ def test_ei_collapses_to_zero_at_zero_variance():
     assert score == pytest.approx(0.0, abs=1e-12)
 
 
-def test_ei_raises_on_degenerate_surrogate_emulator():
-    """`ExpectedImprovement` requires a non-None emulator. Using a
-    `WeightedEmpiricalRandomMeasure` (the no-emulator baseline) at
-    `state.surrogate_distribution` should raise with a message that
-    points the user at the swap."""
+def test_ei_raises_on_degenerate_surrogate_distribution():
+    """`ExpectedImprovement` requires an emulator-backed
+    `EmulatedDistribution`. Passing a `WeightedEmpiricalRandomMeasure`
+    (the no-emulator baseline) should raise from the isinstance narrow
+    in `_score_single`, with a message naming `EmulatedDistribution`."""
     problem = gaussian_2d()
     X = PriorSampler().sample(problem, jax.random.key(0), 8)
     Y = problem.target_map(X)
-    sp = WeightedEmpiricalRandomMeasure(
+    surrogate_distribution = WeightedEmpiricalRandomMeasure(
         X=X,
         log_weights=Y,
         support=problem.support,
@@ -146,10 +146,10 @@ def test_ei_raises_on_degenerate_surrogate_emulator():
     )
     state = AcquisitionState(
         problem=problem,
-        surrogate_distribution=sp,
+        surrogate_distribution=surrogate_distribution,
         X=X,
         Y_raw=Y,
         Y_train=Y,
     )
-    with pytest.raises(ValueError, match="non-degenerate emulator"):
+    with pytest.raises(ValueError, match="EmulatedDistribution"):
         ExpectedImprovement().select_batch(state, q=1, key=jax.random.key(0))

--- a/tests/test_surrogate_distribution.py
+++ b/tests/test_surrogate_distribution.py
@@ -1,9 +1,11 @@
-"""Tests for the v1.2-refactor SurrogateDistribution + WeightedEmpiricalRandomMeasure.
+"""Tests for SurrogateDistribution / EmulatedDistribution / WeightedEmpiricalRandomMeasure.
 
 Coverage:
-- Inheritance: SurrogateDistribution is a NumericRandomMeasure;
-  WeightedEmpiricalRandomMeasure is a SurrogateDistribution subclass with
-  ``emulator=None`` (the degenerate / no-emulator case).
+- Sibling-structure invariants: ``EmulatedDistribution`` and
+  ``WeightedEmpiricalRandomMeasure`` are sibling subclasses of the
+  abstract ``SurrogateDistribution`` base; neither is a subclass of
+  the other.
+- ``EmulatedDistribution`` rejects ``None`` emulator / form at construction.
 - Inner-support / inner-event-shape derived from constructor args.
 - Decoupling from Problem (constructed from math primitives only).
 - Protocol opt-in matrix per class.
@@ -13,10 +15,9 @@ Coverage:
     - (Normal, LogLikPlusPrior) → Normal with shifted loc
     - (MultivariateNormal, Identity / LogLikPlusPrior) — closed-form joint
     - (samplable non-Gaussian, any) → MC empirical via workflow_function
-    - (non-samplable non-Gaussian, any) → raises NotImplementedError
-- expected_target on the SP returns a Distribution that satisfies
-  SupportsUnnormalizedLogProb and SupportsSampling, and sampling delegates
-  to ProbPipe condition_on (NUTS).
+- expected_target on an EmulatedDistribution returns a Distribution
+  that satisfies SupportsUnnormalizedLogProb and SupportsSampling, and
+  sampling delegates to ProbPipe condition_on (NUTS).
 """
 
 from __future__ import annotations
@@ -42,6 +43,7 @@ from probpipe.distributions.continuous import Normal
 from probpipe.distributions.multivariate import MultivariateNormal
 
 from sabi.surrogate import (
+    EmulatedDistribution,
     SurrogateDistribution,
     WeightedEmpiricalRandomMeasure,
     expected_target,
@@ -74,19 +76,19 @@ def _werm(n: int = 16, d: int = 2, seed: int = 0):
     )
 
 
-def _sp(n: int = 20, d: int = 2, seed: int = 1, form=None, prior=None):
-    """A SurrogateDistribution fit on a 2-D Gaussian log-density."""
+def _emulated(n: int = 20, d: int = 2, seed: int = 1, form=None, prior=None):
+    """An `EmulatedDistribution` fit on a 2-D Gaussian log-density."""
     key = jax.random.key(seed)
     X = jax.random.uniform(key, shape=(n, d), minval=-3.0, maxval=3.0)
     Y = -0.5 * jnp.sum(X ** 2, axis=-1)
     emulator = TinyGPEmulator(input_shape=(d,)).fit(X, Y)
-    return SurrogateDistribution(
+    return EmulatedDistribution(
         emulator=emulator,
         log_density_form=form if form is not None else Identity(),
         support=_box_support(d),
         input_shape=(d,),
         prior=prior,
-        name="sp_test",
+        name="emulated_test",
     )
 
 
@@ -95,29 +97,45 @@ def _sp(n: int = 20, d: int = 2, seed: int = 1, form=None, prior=None):
 # -------------------------------------------------------------------------
 
 
-def test_werm_is_surrogate_distribution_subclass():
+def test_sibling_structure_invariants():
+    """`EmulatedDistribution` and `WeightedEmpiricalRandomMeasure` are
+    sibling subclasses of the abstract `SurrogateDistribution`. Neither
+    is a subclass of the other; the abstract base is what lets the loop
+    type their union without committing to either."""
+    assert issubclass(EmulatedDistribution, SurrogateDistribution)
+    assert issubclass(WeightedEmpiricalRandomMeasure, SurrogateDistribution)
+    assert not issubclass(WeightedEmpiricalRandomMeasure, EmulatedDistribution)
+    assert not issubclass(EmulatedDistribution, WeightedEmpiricalRandomMeasure)
+
+
+def test_surrogate_distribution_is_abstract():
+    """The base class can't be instantiated directly — `inner_support`
+    and `inner_event_shape` are abstract."""
+    with pytest.raises(TypeError, match="abstract"):
+        SurrogateDistribution(name="bad")  # type: ignore[abstract]
+
+
+def test_werm_is_random_measure():
     werm = _werm()
     assert isinstance(werm, NumericRandomMeasure)
     assert isinstance(werm, RandomMeasure)
-    # WERM is a SurrogateDistribution subclass with degenerate emulator.
     assert isinstance(werm, SurrogateDistribution)
-    assert werm.emulator is None
-    assert werm.log_density_form is None
 
 
-def test_sp_is_numeric_random_measure():
-    sp = _sp()
-    assert isinstance(sp, SurrogateDistribution)
-    assert isinstance(sp, NumericRandomMeasure)
-    assert isinstance(sp, RandomMeasure)
+def test_emulated_is_random_measure():
+    emulated = _emulated()
+    assert isinstance(emulated, EmulatedDistribution)
+    assert isinstance(emulated, SurrogateDistribution)
+    assert isinstance(emulated, NumericRandomMeasure)
+    assert isinstance(emulated, RandomMeasure)
 
 
 def test_inner_support_and_event_shape_match_constructor_args():
     werm = _werm()
     assert werm.inner_event_shape == (2,)
     assert werm.inner_support is werm._support  # type: ignore[attr-defined]
-    sp = _sp()
-    assert sp.inner_event_shape == (2,)
+    emulated = _emulated()
+    assert emulated.inner_event_shape == (2,)
 
 
 def test_werm_requires_support():
@@ -130,12 +148,12 @@ def test_werm_requires_support():
         )
 
 
-def test_sp_requires_support():
+def test_emulated_distribution_requires_support():
     emulator = TinyGPEmulator(input_shape=(2,)).fit(
         jnp.zeros((4, 2)), jnp.zeros(4)
     )
     with pytest.raises(ValueError, match="support"):
-        SurrogateDistribution(
+        EmulatedDistribution(
             emulator=emulator,
             log_density_form=Identity(),
             support=None,  # type: ignore[arg-type]
@@ -143,29 +161,37 @@ def test_sp_requires_support():
         )
 
 
-def test_require_emulator_returns_emulator_when_present():
-    """Success path: ``require_emulator`` returns ``self.emulator`` unchanged."""
-    sp = _sp()
-    emulator = sp.require_emulator("TestCaller")
-    assert emulator is sp.emulator
-    assert emulator is not None
+def test_emulated_distribution_rejects_none_emulator():
+    """`EmulatedDistribution` requires a non-None emulator. The
+    no-emulator baseline is `WeightedEmpiricalRandomMeasure`."""
+    with pytest.raises(ValueError, match="non-None `emulator`"):
+        EmulatedDistribution(
+            emulator=None,  # type: ignore[arg-type]
+            log_density_form=Identity(),
+            support=_box_support(2),
+            input_shape=(2,),
+        )
 
 
-def test_require_emulator_raises_when_none():
-    """Raise path: ``require_emulator`` raises ``ValueError`` naming the
-    caller and the canonical "non-degenerate emulator" message."""
-    werm = _werm()
-    assert werm.emulator is None
-    with pytest.raises(ValueError, match="MyCaller.*non-degenerate emulator"):
-        werm.require_emulator("MyCaller")
+def test_emulated_distribution_rejects_none_log_density_form():
+    emulator = TinyGPEmulator(input_shape=(2,)).fit(
+        jnp.zeros((4, 2)), jnp.zeros(4)
+    )
+    with pytest.raises(ValueError, match="log_density_form"):
+        EmulatedDistribution(
+            emulator=emulator,
+            log_density_form=None,  # type: ignore[arg-type]
+            support=_box_support(2),
+            input_shape=(2,),
+        )
 
 
-def test_sp_input_shape_must_match_emulator_input_shape():
+def test_emulated_distribution_input_shape_must_match_emulator_input_shape():
     emulator = TinyGPEmulator(input_shape=(2,)).fit(
         jnp.zeros((4, 2)), jnp.zeros(4)
     )
     with pytest.raises(ValueError, match="input_shape"):
-        SurrogateDistribution(
+        EmulatedDistribution(
             emulator=emulator,
             log_density_form=Identity(),
             support=_box_support(3),
@@ -326,44 +352,44 @@ def test_pushforward_forward_model_with_normal_falls_to_mc():
 # -------------------------------------------------------------------------
 
 
-def test_sp_random_unnormalized_log_prob_identity_returns_normal():
-    sp = _sp(form=Identity())
+def test_emulated_random_unnormalized_log_prob_identity_returns_normal():
+    emulated = _emulated(form=Identity())
     # Single-point query: must be presented as batch (per ArrayRandomFunction).
     X = jnp.asarray([[0.4, -0.1], [0.2, 0.3]])
-    marginal = random_unnormalized_log_prob(sp, X)
+    marginal = random_unnormalized_log_prob(emulated, X)
     assert isinstance(marginal, Normal)
-    pred = sp.emulator(X)
+    pred = emulated.emulator(X)
     assert jnp.allclose(jnp.asarray(marginal.loc), jnp.asarray(pred.loc), atol=1e-5)
 
 
-def test_sp_random_unnormalized_log_prob_log_lik_plus_prior_shifts_mean():
+def test_emulated_random_unnormalized_log_prob_log_lik_plus_prior_shifts_mean():
     from probpipe import log_prob as pp_log_prob
     from sabi._probpipe_compat import independent_uniform
 
     prior = independent_uniform(
         low=jnp.full((2,), -5.0), high=jnp.full((2,), 5.0), name="p"
     )
-    sp = _sp(form=LogLikPlusPrior(), prior=prior)
+    emulated = _emulated(form=LogLikPlusPrior(), prior=prior)
     X = jnp.asarray([[0.4, -0.1], [0.2, 0.3]])
-    marginal = random_unnormalized_log_prob(sp, X)
+    marginal = random_unnormalized_log_prob(emulated, X)
     assert isinstance(marginal, Normal)
-    pred = sp.emulator(X)
+    pred = emulated.emulator(X)
     expected_shifts = jax.vmap(lambda x: jnp.asarray(pp_log_prob(prior, x)))(X)
     expected_loc = jnp.asarray(pred.loc) + expected_shifts
     assert jnp.allclose(jnp.asarray(marginal.loc), expected_loc, atol=1e-5)
 
 
-def test_sp_does_not_satisfy_supports_mean():
-    sp = _sp()
-    assert not isinstance(sp, SupportsMean)
+def test_emulated_does_not_satisfy_supports_mean():
+    emulated = _emulated()
+    assert not isinstance(emulated, SupportsMean)
     with pytest.raises(TypeError, match="support"):
-        mean(sp)
+        mean(emulated)
 
 
-def test_sp_does_not_satisfy_supports_random_log_prob():
-    sp = _sp()
-    assert not isinstance(sp, SupportsRandomLogProb)
-    assert isinstance(sp, SupportsRandomUnnormalizedLogProb)
+def test_emulated_does_not_satisfy_supports_random_log_prob():
+    emulated = _emulated()
+    assert not isinstance(emulated, SupportsRandomLogProb)
+    assert isinstance(emulated, SupportsRandomUnnormalizedLogProb)
 
 
 # -------------------------------------------------------------------------
@@ -379,28 +405,28 @@ def test_expected_target_for_werm_is_inner_empirical():
     assert et is mean(werm)
 
 
-def test_expected_target_for_sp_satisfies_unnormalized_log_prob_and_sampling():
-    sp = _sp()
-    et = expected_target(sp)
+def test_expected_target_for_emulated_satisfies_unnormalized_log_prob_and_sampling():
+    emulated = _emulated()
+    et = expected_target(emulated)
     assert isinstance(et, Distribution)
     assert isinstance(et, SupportsUnnormalizedLogProb)
     assert isinstance(et, SupportsSampling)
 
 
-def test_expected_target_for_sp_unnormalized_log_prob_matches_form():
-    sp = _sp()
-    et = expected_target(sp)
+def test_expected_target_for_emulated_unnormalized_log_prob_matches_form():
+    emulated = _emulated()
+    et = expected_target(emulated)
     x = jnp.asarray([0.3, -0.2])
-    pred = sp.emulator(x[None])
+    pred = emulated.emulator(x[None])
     pred_mean = jnp.asarray(mean(pred))[0]
-    expected = float(sp.log_density_form(x, pred_mean, prior=sp.prior))
+    expected = float(emulated.log_density_form(x, pred_mean, prior=emulated.prior))
     assert float(et._unnormalized_log_prob(x)) == pytest.approx(expected, abs=1e-5)
 
 
-def test_expected_target_for_sp_sampling_runs_mcmc():
-    sp = _sp(n=20)
+def test_expected_target_for_emulated_sampling_runs_mcmc():
+    emulated = _emulated(n=20)
     et = expected_target(
-        sp,
+        emulated,
         sampler_kwargs={"num_results": 100, "num_warmup": 50},
     )
     samples = sample(et, key=jax.random.key(0), sample_shape=(40,))


### PR DESCRIPTION
## Summary

Implements **Option 2** from issue #28: aligns the implementation with [docs/design.md §4.5](docs/design.md), which has long said `WeightedEmpiricalRandomMeasure` is a **sibling** of the emulator-backed surrogate, not a subclass.

The previous concrete `SurrogateDistribution` carried `Optional[Emulator]` and `Optional[LogDensityForm]`, making the no-emulator state representable but invalid for most consumers — every emulator-touching path had to defensively guard. This PR makes that state unrepresentable at the type level.

## New class hierarchy

```
NumericRandomMeasure (ProbPipe)
  └── SurrogateDistribution                (sabi abstract base, NEW)
        ├── EmulatedDistribution            (emulator-backed; renamed from previous SurrogateDistribution)
        └── WeightedEmpiricalRandomMeasure  (sibling, no emulator)
```

The renaming preserves every existing field annotation. `AcquisitionState.surrogate_distribution: SurrogateDistribution`, `MetricContext.surrogate_distribution: SurrogateDistribution`, and `Algorithm.estimator: Callable[[SurrogateDistribution], Distribution]` all stay literally unchanged — the annotations now correctly type the union of both subtypes.

Closes #28.

## What changed

**Source (commit 1):**
- `src/sabi/surrogate/surrogate_distribution.py`: hosts both the new abstract `SurrogateDistribution` (declares `inner_support` / `inner_event_shape`) and the renamed `EmulatedDistribution` (non-Optional `emulator` / `log_density_form`). Drops `require_emulator` and the `emulator is None` branch in `_random_unnormalized_log_prob`. Internal `_SurrogateDistributionPushforward` → `_EmulatedDistributionPushforward`.
- `src/sabi/surrogate/weighted_empirical.py`: `WeightedEmpiricalRandomMeasure` now extends the abstract base directly (no `super().__init__(emulator=None, log_density_form=None, ...)`). Inlines `inner_support` / `inner_event_shape`.
- `src/sabi/algorithms/surrogate_distribution_factory.py`: `emulator_pushforward_factory` constructs `EmulatedDistribution`. Factory protocol return type stays `SurrogateDistribution` (the new abstract base).
- `src/sabi/surrogate/estimators.py`: `expected_target` second branch dispatches on `EmulatedDistribution`. Parameter renamed from `sp` to `surrogate_distribution`.
- `src/sabi/acquisitions/{ei,fantasize,optim}.py`: replace `require_emulator(caller)` calls with `isinstance(..., EmulatedDistribution)` narrows that raise on mismatch with a message naming the type. `GreedyMultiPointOptimizer` drops `type(old_sp)(...)` indirection in favor of constructing `EmulatedDistribution` directly after the narrow.
- `src/sabi/surrogate/__init__.py`: re-exports `EmulatedDistribution`.
- Variable rename: every `sp` / `old_sp` / `new_sp` is gone from `src/`. Replaced with `surrogate_distribution`, `current`, or `new_surrogate_distribution`.
- Docstring updates in `acquisitions/base.py`, `metrics/base.py`, `algorithms/loop.py` to describe the new sibling structure.

**Tests (commit 2):**
- `tests/conftest.py::make_acquisition_state` builds an `EmulatedDistribution`.
- `tests/test_surrogate_distribution.py`:
  - The `_sp()` helper is renamed to `_emulated()`; every call site and local variable updated. No more `sp` in the file.
  - Two `require_emulator` unit tests deleted (the helper is gone). Functionality is now exercised by consumer-side isinstance narrows.
  - New test `test_sibling_structure_invariants` pins the hierarchy via `issubclass` / `not issubclass` checks.
  - New test `test_surrogate_distribution_is_abstract` pins the abstract-base invariant.
  - New tests `test_emulated_distribution_rejects_none_emulator` and `test_emulated_distribution_rejects_none_log_density_form` pin the constructor's reject-None invariant.
- `tests/test_acquisitions.py`: stub-emulator construction site uses `EmulatedDistribution`. The "EI raises on degenerate surrogate" test renamed and now matches on `"EmulatedDistribution"` instead of `"non-degenerate emulator"`.

## Test plan

- [x] `scripts/python -m pytest -q` — **348 passed, 5 skipped** (the 5 are `SABI_REGRESSION`-gated benchmark tests; expected). Up from 326 baseline due to new sibling-structure invariant tests minus the two deleted `require_emulator` tests.
- [x] Sibling-structure invariants: `issubclass(EmulatedDistribution, SurrogateDistribution)`, `issubclass(WeightedEmpiricalRandomMeasure, SurrogateDistribution)`, `not issubclass(WeightedEmpiricalRandomMeasure, EmulatedDistribution)`.
- [x] Constructor invariants: `EmulatedDistribution(emulator=None, ...)` raises; `EmulatedDistribution(log_density_form=None, ...)` raises.
- [x] Abstract base: `SurrogateDistribution(...)` raises `TypeError` (abstract methods).
- [x] No `sp` variables remain in `src/` or `tests/` (`grep -rn '\bsp\b' src/ tests/` returns empty).
- [x] No `require_emulator` references remain in `src/` (only the comment in `weighted_empirical.py` and the constructor's `if emulator is None` raise).
- [ ] Reviewer sanity check: clone, `scripts/python -m pytest -q`, confirm 348/5.
- [ ] Reviewer sanity check: run `Algorithm` with `surrogate_distribution_factory=weighted_empirical_factory` + `acquisition=ExpectedImprovement(...)`. Should raise from EI's isinstance narrow with a message naming `EmulatedDistribution`.

## Out of scope (future follow-ups)

- The `weighted_empirical_factory` keeps an `emulator: Emulator` kwarg in its signature that it ignores. Splitting the factory protocol into emulator-needing vs. emulator-free variants is a separate discussion.
- Adding a declarative `Acquisition.requires_sp: ClassVar[tuple[type, ...]]` field (Option 1 from the original issue) is now redundant for the emulator-backed case but could still pay off for future protocol requirements (e.g., Thompson sampling needing `SupportsRandomLogProb`). Track separately.
- Future random measures (VBMC mixture posteriors, etc.) slot in as new `SurrogateDistribution` siblings without touching `EmulatedDistribution` or its consumers — the structure is now in place.
