### PR TITLE
feat(runner): separate run-orchestration from compute backend

### DIFF
--- a/configs/backend/local_parallel.yaml
+++ b/configs/backend/local_parallel.yaml
@@ -1,0 +1,4 @@
+# LocalParallelBackend — run experiments in parallel on local CPU cores.
+# Increase n_workers to match available cores.
+name: local_parallel
+n_workers: 4

--- a/configs/backend/local_sequential.yaml
+++ b/configs/backend/local_sequential.yaml
@@ -1,0 +1,3 @@
+# LocalSequentialBackend — run experiments one at a time in the calling process.
+# Use for local iteration and debugging.
+name: local_sequential

--- a/configs/backend/scc_array.yaml
+++ b/configs/backend/scc_array.yaml
@@ -1,0 +1,19 @@
+# SCCArrayBackend — generate a qsub job-array script for BU SCC (SGE scheduler).
+#
+# dispatch() writes manifest.tsv + qsub_array.sh; submit manually with:
+#   qsub qsub_array.sh
+#
+# Resource knobs — tune per experiment:
+#   cores       : CPU slots per array task
+#   mem_gb      : total memory (GB) per array task
+#   walltime    : wall-clock limit  HH:MM:SS
+#   queue       : SGE queue / parallel-environment name
+#   batch_size  : number of runs bundled into a single array task (default 1)
+#   modules     : list of "module load" arguments for the compute nodes
+name: scc_array
+cores: 4
+mem_gb: 8
+walltime: "12:00:00"
+queue: shared
+batch_size: 1
+modules: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ pyvbmc = ["pyvbmc"]
 # off 0.14 should be a deliberate compatibility audit.
 gpjax = ["gpjax>=0.14,<0.15"]
 
+[project.scripts]
+sabi-submit = "sabi.runner.cli:sabi_submit"
+sabi-aggregate = "sabi.runner.cli:sabi_aggregate"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/sabi"]
 

--- a/scripts/scc_smoke/run_smoke.sh
+++ b/scripts/scc_smoke/run_smoke.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# SCC smoke test — submit a minimal 4-run sweep and verify outputs.
+#
+# Run this script from the repo root on an SCC login node:
+#
+#   bash scripts/scc_smoke/run_smoke.sh
+#
+# It will:
+#   1. Generate manifest.tsv + qsub_array.sh in /tmp/sabi_scc_smoke/
+#   2. Submit the job array via qsub
+#   3. Print the job ID so you can watch it with `qstat`
+#   4. After the array finishes, run: bash scripts/scc_smoke/verify_smoke.sh
+#
+# The sweep: 2 problems × 2 seeds, minimum algorithm config (n_initial=4,
+# n_rounds=1, prior-sampling acquisition, no metrics).  Total wall-time
+# should be under 5 minutes on any modern CPU node.
+#
+# Prerequisites: sabi installed (uv sync), qsub on PATH.
+
+set -euo pipefail
+
+SWEEP_DIR="${SABI_SMOKE_DIR:-/tmp/sabi_scc_smoke}"
+
+echo "Generating sweep under $SWEEP_DIR ..."
+sabi-submit \
+    --backend scc_array \
+    --output-dir "$SWEEP_DIR" \
+    --submit \
+    --scc-walltime 00:15:00 \
+    --scc-cores 4 \
+    --scc-mem-gb 8 \
+    --scc-queue shared \
+    problem=gaussian_2d,banana \
+    acquisition=prior_sampling \
+    algorithm.n_initial=4 \
+    algorithm.n_rounds=1 \
+    metrics=[] \
+    --n-seeds 2
+
+echo ""
+echo "Job submitted.  Monitor with: qstat"
+echo "Once complete, verify with:   bash scripts/scc_smoke/verify_smoke.sh"
+echo "SWEEP_DIR=$SWEEP_DIR"

--- a/scripts/scc_smoke/verify_smoke.sh
+++ b/scripts/scc_smoke/verify_smoke.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Verify SCC smoke test results.
+#
+# Run after the job array submitted by run_smoke.sh has completed:
+#
+#   bash scripts/scc_smoke/verify_smoke.sh
+#
+# Checks:
+#   - All 4 run directories contain summary.json and metrics.jsonl
+#   - sabi-aggregate produces a 4-row Parquet table without errors
+#
+# Exit code: 0 = pass, 1 = fail.
+
+set -euo pipefail
+
+SWEEP_DIR="${SABI_SMOKE_DIR:-/tmp/sabi_scc_smoke}"
+PASS=1
+
+echo "=== Checking run outputs under $SWEEP_DIR ==="
+for run_dir in "$SWEEP_DIR"/*/; do
+    # Skip non-run directories (logs/, etc.)
+    [[ -f "$run_dir/summary.json" ]] || continue
+
+    echo -n "  $run_dir ... "
+    if [[ -f "$run_dir/summary.json" && -f "$run_dir/metrics.jsonl" ]]; then
+        echo "OK"
+    else
+        echo "MISSING FILES"
+        PASS=0
+    fi
+done
+
+echo ""
+echo "=== Running sabi-aggregate ==="
+if sabi-aggregate "$SWEEP_DIR"; then
+    PARQUET="$SWEEP_DIR/sweep_results.parquet"
+    if [[ -f "$PARQUET" ]]; then
+        echo "sweep_results.parquet written."
+    else
+        echo "ERROR: sweep_results.parquet not found after aggregate."
+        PASS=0
+    fi
+else
+    echo "ERROR: sabi-aggregate failed."
+    PASS=0
+fi
+
+echo ""
+if [[ $PASS -eq 1 ]]; then
+    echo "SMOKE TEST PASSED"
+    exit 0
+else
+    echo "SMOKE TEST FAILED — check output above"
+    exit 1
+fi

--- a/src/sabi/runner/__init__.py
+++ b/src/sabi/runner/__init__.py
@@ -1,4 +1,23 @@
+from sabi.runner.backends import (
+    LocalParallelBackend,
+    LocalSequentialBackend,
+    RunBackend,
+    RunSpec,
+    SCCArrayBackend,
+)
 from sabi.runner.build import build_algorithm, build_problem
 from sabi.runner.main import main
+from sabi.runner.sweep import aggregate_sweep, enumerate_sweep
 
-__all__ = ["build_algorithm", "build_problem", "main"]
+__all__ = [
+    "LocalParallelBackend",
+    "LocalSequentialBackend",
+    "RunBackend",
+    "RunSpec",
+    "SCCArrayBackend",
+    "aggregate_sweep",
+    "build_algorithm",
+    "build_problem",
+    "enumerate_sweep",
+    "main",
+]

--- a/src/sabi/runner/backends.py
+++ b/src/sabi/runner/backends.py
@@ -91,10 +91,21 @@ class LocalParallelBackend(RunBackend):
     n_workers: int = 4
 
     def dispatch(self, specs: list[RunSpec]) -> None:
+        failures: list[tuple[RunSpec, BaseException]] = []
         with ProcessPoolExecutor(max_workers=self.n_workers) as pool:
             futures = {pool.submit(_run_subprocess, s): s for s in specs}
             for fut in as_completed(futures):
-                fut.result()  # re-raise CalledProcessError on failure
+                exc = fut.exception()
+                if exc is not None:
+                    failures.append((futures[fut], exc))
+        if failures:
+            lines = [
+                f"  {spec.output_dir}: {type(exc).__name__}: {exc}"
+                for spec, exc in failures
+            ]
+            raise RuntimeError(
+                f"{len(failures)} of {len(specs)} runs failed:\n" + "\n".join(lines)
+            )
 
 
 @dataclass(frozen=True)

--- a/src/sabi/runner/backends.py
+++ b/src/sabi/runner/backends.py
@@ -14,6 +14,7 @@ local ↔ cluster parity is exact.
 
 from __future__ import annotations
 
+import math
 import subprocess
 import sys
 from abc import ABC, abstractmethod
@@ -172,16 +173,21 @@ class SCCArrayBackend(RunBackend):
                 f.write(f"{i}\t{spec.output_dir}\t{overrides_str}\n")
 
     def _write_qsub_script(self, specs: list[RunSpec], sweep_dir: Path) -> None:
-        n_tasks = len(specs)
+        n_specs = len(specs)
+        n_array_tasks = math.ceil(n_specs / self.batch_size)
         module_lines = (
             "\n".join(f"module load {m}" for m in self.modules) if self.modules else ""
         )
         mem_per_core = max(1, self.mem_gb // self.cores)
 
+        # Each array task runs batch_size consecutive manifest rows.
+        # Manifest rows are 1-indexed; file line = row + 1 (header offset).
+        # The last task may run fewer than batch_size rows when n_specs is not
+        # a multiple of batch_size.
         script = f"""\
 #!/bin/bash
 #$ -N sabi_sweep
-#$ -t 1-{n_tasks}
+#$ -t 1-{n_array_tasks}
 #$ -pe omp {self.cores}
 #$ -l h_rt={self.walltime}
 #$ -l mem_per_core={mem_per_core}G
@@ -193,13 +199,19 @@ class SCCArrayBackend(RunBackend):
 {module_lines}
 
 MANIFEST={sweep_dir}/manifest.tsv
+BATCH_SIZE={self.batch_size}
+N_SPECS={n_specs}
 
-# Manifest line for this task: header is line 1, so task N is line N+1.
-LINE=$(awk -v t=$SGE_TASK_ID 'NR == t + 1' "$MANIFEST")
-OUTPUT_DIR=$(printf '%s' "$LINE" | cut -f2)
-OVERRIDES=$(printf '%s' "$LINE" | cut -f3)
+START=$(( (SGE_TASK_ID - 1) * BATCH_SIZE + 1 ))
+END=$(( SGE_TASK_ID * BATCH_SIZE ))
+if [ $END -gt $N_SPECS ]; then END=$N_SPECS; fi
 
-mkdir -p "$OUTPUT_DIR"
-{self.python_exe} -m sabi.runner hydra.run.dir="$OUTPUT_DIR" $OVERRIDES
+for ROW in $(seq $START $END); do
+    LINE=$(awk -v r="$ROW" 'NR == r + 1' "$MANIFEST")
+    OUTPUT_DIR=$(printf '%s' "$LINE" | cut -f2)
+    OVERRIDES=$(printf '%s' "$LINE" | cut -f3)
+    mkdir -p "$OUTPUT_DIR"
+    {self.python_exe} -m sabi.runner hydra.run.dir="$OUTPUT_DIR" $OVERRIDES
+done
 """
         (sweep_dir / "qsub_array.sh").write_text(script)

--- a/src/sabi/runner/backends.py
+++ b/src/sabi/runner/backends.py
@@ -145,6 +145,9 @@ class SCCArrayBackend(RunBackend):
         Python executable path to use inside the qsub script.  Defaults to
         the interpreter running ``sabi-submit``, which is correct when the
         cluster nodes share the same file system mount.
+    submit:
+        When ``True``, call ``qsub qsub_array.sh`` automatically after
+        writing the script.  Requires ``qsub`` to be on ``PATH``.
     """
 
     cores: int = 4
@@ -154,6 +157,7 @@ class SCCArrayBackend(RunBackend):
     batch_size: int = 1
     modules: tuple[str, ...] = field(default_factory=tuple)
     python_exe: str = sys.executable
+    submit: bool = False
 
     def dispatch(self, specs: list[RunSpec]) -> None:
         if not specs:
@@ -163,6 +167,9 @@ class SCCArrayBackend(RunBackend):
         (sweep_dir / "logs").mkdir(exist_ok=True)
         self._write_manifest(specs, sweep_dir)
         self._write_qsub_script(specs, sweep_dir)
+        if self.submit:
+            script_path = sweep_dir / "qsub_array.sh"
+            subprocess.run(["qsub", str(script_path)], check=True, cwd=sweep_dir)
 
     def _write_manifest(self, specs: list[RunSpec], sweep_dir: Path) -> None:
         manifest_path = sweep_dir / "manifest.tsv"

--- a/src/sabi/runner/backends.py
+++ b/src/sabi/runner/backends.py
@@ -18,6 +18,7 @@ import math
 import subprocess
 import sys
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -148,6 +149,12 @@ class SCCArrayBackend(RunBackend):
     submit:
         When ``True``, call ``qsub qsub_array.sh`` automatically after
         writing the script.  Requires ``qsub`` to be on ``PATH``.
+    group_by_experiment:
+        When ``True``, group specs that share the same non-``seed`` overrides
+        into a single array task, so that all replicates of one experiment run
+        sequentially on the same node.  A companion ``groups.tsv`` is written
+        alongside the manifest so the script knows each task's row range.
+        ``batch_size`` is ignored when this flag is set.
     """
 
     cores: int = 4
@@ -158,6 +165,7 @@ class SCCArrayBackend(RunBackend):
     modules: tuple[str, ...] = field(default_factory=tuple)
     python_exe: str = sys.executable
     submit: bool = False
+    group_by_experiment: bool = False
 
     def dispatch(self, specs: list[RunSpec]) -> None:
         if not specs:
@@ -165,8 +173,16 @@ class SCCArrayBackend(RunBackend):
         sweep_dir = specs[0].output_dir.parent
         sweep_dir.mkdir(parents=True, exist_ok=True)
         (sweep_dir / "logs").mkdir(exist_ok=True)
-        self._write_manifest(specs, sweep_dir)
-        self._write_qsub_script(specs, sweep_dir)
+
+        if self.group_by_experiment:
+            ordered, groups = _group_by_experiment(specs)
+            self._write_manifest(ordered, sweep_dir)
+            self._write_groups_file(groups, sweep_dir)
+            self._write_qsub_script_grouped(groups, sweep_dir)
+        else:
+            self._write_manifest(specs, sweep_dir)
+            self._write_qsub_script(specs, sweep_dir)
+
         if self.submit:
             script_path = sweep_dir / "qsub_array.sh"
             subprocess.run(["qsub", str(script_path)], check=True, cwd=sweep_dir)
@@ -222,3 +238,79 @@ for ROW in $(seq $START $END); do
 done
 """
         (sweep_dir / "qsub_array.sh").write_text(script)
+
+    def _write_groups_file(
+        self, groups: list[list[RunSpec]], sweep_dir: Path
+    ) -> None:
+        """Write groups.tsv: task_id → (start_row, end_row) in the manifest."""
+        groups_path = sweep_dir / "groups.tsv"
+        row = 1
+        with groups_path.open("w") as f:
+            f.write("task_id\tstart_row\tend_row\n")
+            for task_id, group in enumerate(groups, start=1):
+                f.write(f"{task_id}\t{row}\t{row + len(group) - 1}\n")
+                row += len(group)
+
+    def _write_qsub_script_grouped(
+        self, groups: list[list[RunSpec]], sweep_dir: Path
+    ) -> None:
+        """Write qsub_array.sh for group_by_experiment mode.
+
+        Each array task reads its row range from groups.tsv and runs
+        all specs in that range sequentially.
+        """
+        n_array_tasks = len(groups)
+        module_lines = (
+            "\n".join(f"module load {m}" for m in self.modules) if self.modules else ""
+        )
+        mem_per_core = max(1, self.mem_gb // self.cores)
+
+        script = f"""\
+#!/bin/bash
+#$ -N sabi_sweep
+#$ -t 1-{n_array_tasks}
+#$ -pe omp {self.cores}
+#$ -l h_rt={self.walltime}
+#$ -l mem_per_core={mem_per_core}G
+#$ -q {self.queue}
+#$ -j y
+#$ -o {sweep_dir}/logs/
+#$ -cwd
+
+{module_lines}
+
+MANIFEST={sweep_dir}/manifest.tsv
+GROUPS={sweep_dir}/groups.tsv
+
+GROUP_LINE=$(awk -v t="$SGE_TASK_ID" 'NR == t + 1' "$GROUPS")
+START=$(printf '%s' "$GROUP_LINE" | cut -f2)
+END=$(printf '%s' "$GROUP_LINE" | cut -f3)
+
+for ROW in $(seq "$START" "$END"); do
+    LINE=$(awk -v r="$ROW" 'NR == r + 1' "$MANIFEST")
+    OUTPUT_DIR=$(printf '%s' "$LINE" | cut -f2)
+    OVERRIDES=$(printf '%s' "$LINE" | cut -f3)
+    mkdir -p "$OUTPUT_DIR"
+    {self.python_exe} -m sabi.runner hydra.run.dir="$OUTPUT_DIR" $OVERRIDES
+done
+"""
+        (sweep_dir / "qsub_array.sh").write_text(script)
+
+
+def _group_by_experiment(
+    specs: list[RunSpec],
+) -> tuple[list[RunSpec], list[list[RunSpec]]]:
+    """Group specs sharing the same non-seed overrides.
+
+    Returns a tuple of:
+    - *ordered*: specs sorted so all seeds of each experiment are consecutive.
+    - *groups*: the same specs partitioned into per-experiment lists,
+      preserving the order in which experiments first appear in *specs*.
+    """
+    group_map: dict[tuple[str, ...], list[RunSpec]] = defaultdict(list)
+    for spec in specs:
+        key = tuple(o for o in spec.overrides if not o.startswith("seed="))
+        group_map[key].append(spec)
+    groups = list(group_map.values())
+    ordered = [s for group in groups for s in group]
+    return ordered, groups

--- a/src/sabi/runner/backends.py
+++ b/src/sabi/runner/backends.py
@@ -1,0 +1,194 @@
+"""Execution backends for sabi sweeps.
+
+Each backend implements ``dispatch(specs)`` — the contract is:
+
+- :class:`LocalSequentialBackend` and :class:`LocalParallelBackend` block
+  until all runs complete.
+- :class:`SCCArrayBackend` writes ``manifest.tsv`` + ``qsub_array.sh`` to the
+  sweep directory and returns immediately; the user submits the script with
+  ``qsub qsub_array.sh`` (or passes ``--submit`` to ``sabi-submit``).
+
+All backends execute runs via ``python -m sabi.runner <overrides>``, so
+local ↔ cluster parity is exact.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from abc import ABC, abstractmethod
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    """Specification for a single sabi run.
+
+    Parameters
+    ----------
+    overrides:
+        Hydra override strings, e.g. ``("problem=gaussian_2d", "seed=0")``.
+    output_dir:
+        Directory where this run's outputs (``metrics.jsonl``,
+        ``summary.json``, ``config.yaml``) will be written.
+    """
+
+    overrides: tuple[str, ...]
+    output_dir: Path
+
+
+def _run_subprocess(spec: RunSpec) -> None:
+    """Execute one run by invoking ``sabi.runner.main`` as a subprocess.
+
+    The subprocess inherits the current environment (including ``PYTHONPATH``),
+    so whichever ``python`` is active in the caller also resolves ``sabi``.
+    """
+    spec.output_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        "-m",
+        "sabi.runner",
+        f"hydra.run.dir={spec.output_dir}",
+        *spec.overrides,
+    ]
+    subprocess.run(cmd, check=True)
+
+
+class RunBackend(ABC):
+    """Abstract base for sabi execution backends."""
+
+    @abstractmethod
+    def dispatch(self, specs: list[RunSpec]) -> None:
+        """Execute or schedule all runs in *specs*.
+
+        Parameters
+        ----------
+        specs:
+            Non-empty list of :class:`RunSpec` objects to dispatch.
+        """
+
+
+class LocalSequentialBackend(RunBackend):
+    """Execute runs one at a time in the calling process."""
+
+    def dispatch(self, specs: list[RunSpec]) -> None:
+        for spec in specs:
+            _run_subprocess(spec)
+
+
+@dataclass(frozen=True)
+class LocalParallelBackend(RunBackend):
+    """Execute runs in parallel using a local process pool.
+
+    Parameters
+    ----------
+    n_workers:
+        Maximum number of concurrent subprocesses.
+    """
+
+    n_workers: int = 4
+
+    def dispatch(self, specs: list[RunSpec]) -> None:
+        with ProcessPoolExecutor(max_workers=self.n_workers) as pool:
+            futures = {pool.submit(_run_subprocess, s): s for s in specs}
+            for fut in as_completed(futures):
+                fut.result()  # re-raise CalledProcessError on failure
+
+
+@dataclass(frozen=True)
+class SCCArrayBackend(RunBackend):
+    """Generate a qsub job-array script for the BU SCC (SGE scheduler).
+
+    :meth:`dispatch` writes two files under the sweep directory:
+
+    ``manifest.tsv``
+        One row per run: ``task_id``, ``output_dir``, ``overrides``.
+    ``qsub_array.sh``
+        An SGE array job script.  Each task reads its row from the manifest
+        and calls ``python -m sabi.runner`` with the stored overrides.
+
+    The script is *not* submitted automatically — run ``qsub qsub_array.sh``
+    in the sweep directory, or pass ``--submit`` to ``sabi-submit``.
+
+    Parameters
+    ----------
+    cores:
+        Cores (slots) requested per array task.
+    mem_gb:
+        Total memory (GB) requested per array task.
+    walltime:
+        Wall-clock time limit in ``HH:MM:SS`` format.
+    queue:
+        SGE queue / parallel environment name (e.g. ``"shared"``,
+        ``"gpu_scc"``).
+    batch_size:
+        Number of consecutive manifest rows executed inside a single array
+        task.  ``1`` (default) gives the finest-grained retry granularity.
+    modules:
+        ``module load`` arguments to prepend to the script, e.g.
+        ``("python3/3.12.3", "cuda/12.2")``.
+    python_exe:
+        Python executable path to use inside the qsub script.  Defaults to
+        the interpreter running ``sabi-submit``, which is correct when the
+        cluster nodes share the same file system mount.
+    """
+
+    cores: int = 4
+    mem_gb: int = 8
+    walltime: str = "12:00:00"
+    queue: str = "shared"
+    batch_size: int = 1
+    modules: tuple[str, ...] = field(default_factory=tuple)
+    python_exe: str = sys.executable
+
+    def dispatch(self, specs: list[RunSpec]) -> None:
+        if not specs:
+            return
+        sweep_dir = specs[0].output_dir.parent
+        sweep_dir.mkdir(parents=True, exist_ok=True)
+        (sweep_dir / "logs").mkdir(exist_ok=True)
+        self._write_manifest(specs, sweep_dir)
+        self._write_qsub_script(specs, sweep_dir)
+
+    def _write_manifest(self, specs: list[RunSpec], sweep_dir: Path) -> None:
+        manifest_path = sweep_dir / "manifest.tsv"
+        with manifest_path.open("w") as f:
+            f.write("task_id\toutput_dir\toverrides\n")
+            for i, spec in enumerate(specs, start=1):
+                overrides_str = " ".join(spec.overrides)
+                f.write(f"{i}\t{spec.output_dir}\t{overrides_str}\n")
+
+    def _write_qsub_script(self, specs: list[RunSpec], sweep_dir: Path) -> None:
+        n_tasks = len(specs)
+        module_lines = (
+            "\n".join(f"module load {m}" for m in self.modules) if self.modules else ""
+        )
+        mem_per_core = max(1, self.mem_gb // self.cores)
+
+        script = f"""\
+#!/bin/bash
+#$ -N sabi_sweep
+#$ -t 1-{n_tasks}
+#$ -pe omp {self.cores}
+#$ -l h_rt={self.walltime}
+#$ -l mem_per_core={mem_per_core}G
+#$ -q {self.queue}
+#$ -j y
+#$ -o {sweep_dir}/logs/
+#$ -cwd
+
+{module_lines}
+
+MANIFEST={sweep_dir}/manifest.tsv
+
+# Manifest line for this task: header is line 1, so task N is line N+1.
+LINE=$(awk -v t=$SGE_TASK_ID 'NR == t + 1' "$MANIFEST")
+OUTPUT_DIR=$(printf '%s' "$LINE" | cut -f2)
+OVERRIDES=$(printf '%s' "$LINE" | cut -f3)
+
+mkdir -p "$OUTPUT_DIR"
+{self.python_exe} -m sabi.runner hydra.run.dir="$OUTPUT_DIR" $OVERRIDES
+"""
+        (sweep_dir / "qsub_array.sh").write_text(script)

--- a/src/sabi/runner/cli.py
+++ b/src/sabi/runner/cli.py
@@ -134,6 +134,27 @@ def sabi_submit() -> None:
         help="SCC only: call qsub automatically after writing the script.",
     )
     parser.add_argument(
+        "--group-by-experiment",
+        action="store_true",
+        default=False,
+        dest="group_by_experiment",
+        help=(
+            "SCC only: group specs sharing the same non-seed overrides into "
+            "one array task, so all replicates of an experiment run on the "
+            "same node.  Writes groups.tsv alongside the manifest."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        dest="dry_run",
+        help=(
+            "Print what would be dispatched (spec count, override combinations, "
+            "estimated array size) without running anything."
+        ),
+    )
+    parser.add_argument(
         "overrides",
         nargs="*",
         metavar="KEY=VALUE[,VALUE...]",
@@ -153,9 +174,32 @@ def sabi_submit() -> None:
         print("sabi-submit: no run specs generated — check your overrides.", file=sys.stderr)
         sys.exit(1)
 
+    if args.dry_run:
+        _print_dry_run(specs, args)
+        return
+
     print(f"Dispatching {len(specs)} runs via {args.backend}...")
     backend.dispatch(specs)
     print("Done.")
+
+
+def _print_dry_run(specs: list, args: argparse.Namespace) -> None:
+    from sabi.runner.backends import _group_by_experiment
+
+    print(f"DRY RUN — {len(specs)} spec(s), backend={args.backend}")
+    print(f"Output dir: {args.output_dir}")
+    if args.backend == "scc_array":
+        if args.group_by_experiment:
+            _, groups = _group_by_experiment(specs)
+            n_tasks = len(groups)
+            print(f"group_by_experiment=True → {n_tasks} array task(s)")
+        else:
+            import math
+            n_tasks = math.ceil(len(specs) / args.scc_batch_size)
+            print(f"batch_size={args.scc_batch_size} → {n_tasks} array task(s)")
+    print("Specs:")
+    for spec in specs:
+        print(f"  {' '.join(spec.overrides)}  →  {spec.output_dir}")
 
 
 def _build_backend(args: argparse.Namespace) -> RunBackend:
@@ -173,6 +217,7 @@ def _build_backend(args: argparse.Namespace) -> RunBackend:
             modules=tuple(args.scc_modules),
             python_exe=args.scc_python,
             submit=args.submit,
+            group_by_experiment=args.group_by_experiment,
         )
     raise ValueError(f"Unknown backend: {args.backend!r}")  # unreachable
 

--- a/src/sabi/runner/cli.py
+++ b/src/sabi/runner/cli.py
@@ -1,0 +1,194 @@
+"""CLI entry points for sabi sweep orchestration.
+
+``sabi-submit``
+    Enumerate a Cartesian product of config overrides and dispatch them to
+    an execution backend (local sequential, local parallel, or SCC array).
+
+``sabi-aggregate``
+    Collect per-run outputs from a completed sweep into a single Parquet table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from sabi.runner.backends import (
+    LocalParallelBackend,
+    LocalSequentialBackend,
+    RunBackend,
+    SCCArrayBackend,
+)
+from sabi.runner.sweep import aggregate_sweep, enumerate_sweep
+
+
+def sabi_submit() -> None:
+    """Entry point for the ``sabi-submit`` command."""
+    parser = argparse.ArgumentParser(
+        prog="sabi-submit",
+        description=(
+            "Enumerate a sweep and dispatch runs to a backend.\n\n"
+            "Overrides use Hydra multirun notation: comma-separated values\n"
+            "expand into the Cartesian product, e.g.:\n\n"
+            "  sabi-submit --backend local_parallel --output-dir ./sweep \\\n"
+            "      problem=gaussian_2d,banana acquisition=ei seed=0,1,2"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--backend",
+        default="local_sequential",
+        choices=["local_sequential", "local_parallel", "scc_array"],
+        help="Execution backend (default: local_sequential).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        dest="output_dir",
+        metavar="DIR",
+        help="Root directory for sweep outputs.",
+    )
+    parser.add_argument(
+        "--n-seeds",
+        type=int,
+        default=None,
+        dest="n_seeds",
+        metavar="N",
+        help=(
+            "Number of random seeds (expands to seed=0,1,...,N-1). "
+            "Cannot be combined with an explicit seed= override."
+        ),
+    )
+    # local_parallel knob
+    parser.add_argument(
+        "--n-workers",
+        type=int,
+        default=4,
+        dest="n_workers",
+        metavar="N",
+        help="Parallel worker processes (local_parallel only, default: 4).",
+    )
+    # SCC knobs
+    parser.add_argument(
+        "--scc-cores",
+        type=int,
+        default=4,
+        dest="scc_cores",
+        metavar="N",
+        help="CPU slots per array task (default: 4).",
+    )
+    parser.add_argument(
+        "--scc-mem-gb",
+        type=int,
+        default=8,
+        dest="scc_mem_gb",
+        metavar="GB",
+        help="Total memory (GB) per array task (default: 8).",
+    )
+    parser.add_argument(
+        "--scc-walltime",
+        default="12:00:00",
+        dest="scc_walltime",
+        metavar="HH:MM:SS",
+        help="Wall-clock time limit (default: 12:00:00).",
+    )
+    parser.add_argument(
+        "--scc-queue",
+        default="shared",
+        dest="scc_queue",
+        metavar="QUEUE",
+        help="SGE queue name (default: shared).",
+    )
+    parser.add_argument(
+        "--scc-batch-size",
+        type=int,
+        default=1,
+        dest="scc_batch_size",
+        metavar="N",
+        help="Runs per array task (default: 1).",
+    )
+    parser.add_argument(
+        "--scc-module",
+        action="append",
+        default=[],
+        dest="scc_modules",
+        metavar="MODULE",
+        help="Module to load on SCC nodes (repeatable), e.g. python3/3.12.3.",
+    )
+    parser.add_argument(
+        "--scc-python",
+        default=sys.executable,
+        dest="scc_python",
+        metavar="PATH",
+        help=(
+            "Python executable path written into the qsub script "
+            "(default: current interpreter)."
+        ),
+    )
+    parser.add_argument(
+        "overrides",
+        nargs="*",
+        metavar="KEY=VALUE[,VALUE...]",
+        help="Hydra-style override strings.",
+    )
+
+    args = parser.parse_args()
+    backend = _build_backend(args)
+
+    try:
+        specs = enumerate_sweep(args.overrides, args.output_dir, n_seeds=args.n_seeds)
+    except ValueError as exc:
+        print(f"sabi-submit: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not specs:
+        print("sabi-submit: no run specs generated — check your overrides.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Dispatching {len(specs)} runs via {args.backend}...")
+    backend.dispatch(specs)
+    print("Done.")
+
+
+def _build_backend(args: argparse.Namespace) -> RunBackend:
+    if args.backend == "local_sequential":
+        return LocalSequentialBackend()
+    if args.backend == "local_parallel":
+        return LocalParallelBackend(n_workers=args.n_workers)
+    if args.backend == "scc_array":
+        return SCCArrayBackend(
+            cores=args.scc_cores,
+            mem_gb=args.scc_mem_gb,
+            walltime=args.scc_walltime,
+            queue=args.scc_queue,
+            batch_size=args.scc_batch_size,
+            modules=tuple(args.scc_modules),
+            python_exe=args.scc_python,
+        )
+    raise ValueError(f"Unknown backend: {args.backend!r}")  # unreachable
+
+
+def sabi_aggregate() -> None:
+    """Entry point for the ``sabi-aggregate`` command."""
+    parser = argparse.ArgumentParser(
+        prog="sabi-aggregate",
+        description="Collect sweep run outputs into a single Parquet table.",
+    )
+    parser.add_argument(
+        "sweep_dir",
+        type=Path,
+        metavar="DIR",
+        help="Sweep root directory produced by sabi-submit.",
+    )
+    args = parser.parse_args()
+
+    try:
+        table = aggregate_sweep(args.sweep_dir)
+    except ValueError as exc:
+        print(f"sabi-aggregate: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Columns : {table.schema.names}")
+    print(f"Rows    : {len(table)}")

--- a/src/sabi/runner/cli.py
+++ b/src/sabi/runner/cli.py
@@ -128,6 +128,12 @@ def sabi_submit() -> None:
         ),
     )
     parser.add_argument(
+        "--submit",
+        action="store_true",
+        default=False,
+        help="SCC only: call qsub automatically after writing the script.",
+    )
+    parser.add_argument(
         "overrides",
         nargs="*",
         metavar="KEY=VALUE[,VALUE...]",
@@ -166,6 +172,7 @@ def _build_backend(args: argparse.Namespace) -> RunBackend:
             batch_size=args.scc_batch_size,
             modules=tuple(args.scc_modules),
             python_exe=args.scc_python,
+            submit=args.submit,
         )
     raise ValueError(f"Unknown backend: {args.backend!r}")  # unreachable
 

--- a/src/sabi/runner/sweep.py
+++ b/src/sabi/runner/sweep.py
@@ -22,7 +22,6 @@ from pathlib import Path
 
 import pyarrow as pa
 import pyarrow.parquet as pq
-from omegaconf import OmegaConf
 
 from sabi.runner.backends import RunSpec
 
@@ -88,15 +87,57 @@ def enumerate_sweep(
     return specs
 
 
+def _load_manifest(sweep_dir: Path) -> dict[str, dict[str, str | int | float]]:
+    """Parse ``manifest.tsv`` → mapping from output_dir string to override dict.
+
+    Override values are coerced to ``int`` or ``float`` where possible so
+    that numeric sweep dimensions (``seed``, ``algorithm.n_rounds``, etc.)
+    arrive as the right type in the aggregated table.
+    """
+    manifest_path = sweep_dir / "manifest.tsv"
+    if not manifest_path.exists():
+        return {}
+    result: dict[str, dict[str, str | int | float]] = {}
+    for line in manifest_path.read_text().splitlines()[1:]:  # skip header
+        parts = line.split("\t", 2)
+        if len(parts) < 3:
+            continue
+        _, out_dir, overrides_str = parts
+        overrides: dict[str, str | int | float] = {}
+        for token in overrides_str.split():
+            if "=" in token:
+                k, v = token.split("=", 1)
+                overrides[k] = _coerce(v)
+        result[out_dir.strip()] = overrides
+    return result
+
+
+def _coerce(v: str) -> str | int | float:
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    try:
+        return float(v)
+    except ValueError:
+        pass
+    return v
+
+
 def aggregate_sweep(sweep_dir: Path) -> pa.Table:
     """Collect per-run outputs from a completed sweep into a tidy table.
 
     For each subdirectory of *sweep_dir* that contains a ``summary.json``
-    file, reads ``summary.json``, ``config.yaml``, and the last row of
+    file, reads the manifest (primary), ``summary.json``, and the last row of
     ``metrics.jsonl`` (if present) and merges everything into one row.
 
+    Override columns come from ``manifest.tsv`` when available, covering all
+    submitted keys including nested ones (e.g. ``algorithm.n_rounds``).  This
+    is more complete than reading ``config.yaml``, which only surfaces fields
+    that happen to appear at the Hydra top level.
+
     Writes the result to ``sweep_dir/sweep_results.parquet`` and returns the
-    :class:`pyarrow.Table` (rows = runs, columns = config keys + metrics).
+    :class:`pyarrow.Table` (rows = runs, columns = override keys + metrics).
 
     Parameters
     ----------
@@ -109,6 +150,7 @@ def aggregate_sweep(sweep_dir: Path) -> pa.Table:
     ValueError
         If no completed runs (subdirectories with ``summary.json``) are found.
     """
+    manifest_overrides = _load_manifest(sweep_dir)
     rows: list[dict] = []
 
     for run_dir in sorted(sweep_dir.iterdir()):
@@ -121,17 +163,8 @@ def aggregate_sweep(sweep_dir: Path) -> pa.Table:
         summary = json.loads(summary_path.read_text())
         row: dict = {"run_dir": str(run_dir)}
 
-        # Pull top-level config fields from the saved config.yaml.
-        config_path = run_dir / "config.yaml"
-        if config_path.exists():
-            cfg = OmegaConf.load(config_path)
-            row["seed"] = int(cfg.get("seed", -1))
-            if hasattr(cfg, "problem"):
-                row["problem"] = str(cfg.problem.get("name", ""))
-            if hasattr(cfg, "emulator"):
-                row["emulator"] = str(cfg.emulator.get("name", ""))
-            if hasattr(cfg, "acquisition"):
-                row["acquisition"] = str(cfg.acquisition.get("name", ""))
+        # Override values from manifest (covers all submitted keys).
+        row.update(manifest_overrides.get(str(run_dir), {}))
 
         row["n_evals_final"] = summary.get("n_evals_final")
         for k, v in summary.get("final_metrics", {}).items():
@@ -140,7 +173,7 @@ def aggregate_sweep(sweep_dir: Path) -> pa.Table:
         # Last-round metrics from metrics.jsonl.
         metrics_path = run_dir / "metrics.jsonl"
         if metrics_path.exists():
-            lines = [l for l in metrics_path.read_text().splitlines() if l.strip()]
+            lines = [ln for ln in metrics_path.read_text().splitlines() if ln.strip()]
             if lines:
                 for k, v in json.loads(lines[-1]).items():
                     row[f"last_round_{k}"] = v

--- a/src/sabi/runner/sweep.py
+++ b/src/sabi/runner/sweep.py
@@ -1,0 +1,157 @@
+"""Sweep enumeration and result aggregation.
+
+Sweep enumeration
+-----------------
+:func:`enumerate_sweep` expands a list of Hydra-style override strings into
+the full Cartesian product of :class:`~sabi.runner.backends.RunSpec` objects.
+Multi-value overrides use comma-separated notation (``key=v1,v2,...``),
+mirroring Hydra's multirun syntax.
+
+Result aggregation
+------------------
+:func:`aggregate_sweep` walks a completed sweep directory, reads each run's
+``summary.json`` and ``metrics.jsonl``, and returns a :class:`pyarrow.Table`
+(also written to ``sweep_results.parquet`` in the sweep directory).
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from omegaconf import OmegaConf
+
+from sabi.runner.backends import RunSpec
+
+
+def enumerate_sweep(
+    overrides: list[str],
+    sweep_dir: Path,
+    *,
+    n_seeds: int | None = None,
+) -> list[RunSpec]:
+    """Parse override strings and enumerate the Cartesian product as RunSpecs.
+
+    Each override of the form ``key=v1,v2,...`` is expanded; single-value
+    overrides (``key=v``) are held constant across all specs.
+
+    Parameters
+    ----------
+    overrides:
+        Hydra-style override strings.  Multi-value overrides use comma
+        separation, e.g. ``["problem=gaussian_2d,banana", "seed=0,1"]``.
+    sweep_dir:
+        Root directory for this sweep.  Each :class:`RunSpec` receives a
+        unique subdirectory derived from the override combination.
+    n_seeds:
+        When provided, inject ``seed=0,1,...,n_seeds-1`` automatically.
+        Raises :class:`ValueError` if ``seed=`` already appears in
+        *overrides* to prevent ambiguity.
+
+    Returns
+    -------
+    list[RunSpec]
+        One spec per Cartesian combination, in lexicographic override order.
+    """
+    overrides = list(overrides)
+    if n_seeds is not None:
+        if n_seeds < 1:
+            raise ValueError(f"n_seeds must be >= 1, got {n_seeds}.")
+        if any(o.startswith("seed=") for o in overrides):
+            raise ValueError(
+                "Cannot combine --n-seeds with an explicit seed= override."
+            )
+        overrides.append("seed=" + ",".join(str(i) for i in range(n_seeds)))
+
+    parsed: list[tuple[str, list[str]]] = []
+    for override in overrides:
+        if "=" not in override:
+            raise ValueError(
+                f"Override {override!r} has no '=' separator.  "
+                "Expected the form key=value or key=v1,v2,..."
+            )
+        key, vals_str = override.split("=", 1)
+        parsed.append((key, vals_str.split(",")))
+
+    keys = [k for k, _ in parsed]
+    value_lists = [vs for _, vs in parsed]
+
+    specs: list[RunSpec] = []
+    for combo in itertools.product(*value_lists):
+        combo_overrides = tuple(f"{k}={v}" for k, v in zip(keys, combo))
+        run_name = "_".join(f"{k}-{v}" for k, v in zip(keys, combo))
+        specs.append(RunSpec(overrides=combo_overrides, output_dir=sweep_dir / run_name))
+
+    return specs
+
+
+def aggregate_sweep(sweep_dir: Path) -> pa.Table:
+    """Collect per-run outputs from a completed sweep into a tidy table.
+
+    For each subdirectory of *sweep_dir* that contains a ``summary.json``
+    file, reads ``summary.json``, ``config.yaml``, and the last row of
+    ``metrics.jsonl`` (if present) and merges everything into one row.
+
+    Writes the result to ``sweep_dir/sweep_results.parquet`` and returns the
+    :class:`pyarrow.Table` (rows = runs, columns = config keys + metrics).
+
+    Parameters
+    ----------
+    sweep_dir:
+        Root directory of a sweep previously dispatched by
+        :class:`~sabi.runner.backends.RunBackend`.
+
+    Raises
+    ------
+    ValueError
+        If no completed runs (subdirectories with ``summary.json``) are found.
+    """
+    rows: list[dict] = []
+
+    for run_dir in sorted(sweep_dir.iterdir()):
+        if not run_dir.is_dir():
+            continue
+        summary_path = run_dir / "summary.json"
+        if not summary_path.exists():
+            continue
+
+        summary = json.loads(summary_path.read_text())
+        row: dict = {"run_dir": str(run_dir)}
+
+        # Pull top-level config fields from the saved config.yaml.
+        config_path = run_dir / "config.yaml"
+        if config_path.exists():
+            cfg = OmegaConf.load(config_path)
+            row["seed"] = int(cfg.get("seed", -1))
+            if hasattr(cfg, "problem"):
+                row["problem"] = str(cfg.problem.get("name", ""))
+            if hasattr(cfg, "emulator"):
+                row["emulator"] = str(cfg.emulator.get("name", ""))
+            if hasattr(cfg, "acquisition"):
+                row["acquisition"] = str(cfg.acquisition.get("name", ""))
+
+        row["n_evals_final"] = summary.get("n_evals_final")
+        for k, v in summary.get("final_metrics", {}).items():
+            row[f"final_{k}"] = v
+
+        # Last-round metrics from metrics.jsonl.
+        metrics_path = run_dir / "metrics.jsonl"
+        if metrics_path.exists():
+            lines = [l for l in metrics_path.read_text().splitlines() if l.strip()]
+            if lines:
+                for k, v in json.loads(lines[-1]).items():
+                    row[f"last_round_{k}"] = v
+
+        rows.append(row)
+
+    if not rows:
+        raise ValueError(f"No completed runs found under {sweep_dir}.")
+
+    table = pa.Table.from_pylist(rows)
+    out_path = sweep_dir / "sweep_results.parquet"
+    pq.write_table(table, out_path)
+    print(f"Wrote {len(rows)} rows → {out_path}")
+    return table

--- a/tests/test_runner_backends.py
+++ b/tests/test_runner_backends.py
@@ -190,6 +190,38 @@ def test_scc_backend_empty_specs_is_noop(tmp_path):
     assert not (tmp_path / "manifest.tsv").exists()
 
 
+def test_scc_backend_batch_size_reduces_array_tasks(tmp_path):
+    # 6 specs with batch_size=2 → 3 array tasks.
+    specs = _make_specs(tmp_path, n=6)
+    SCCArrayBackend(batch_size=2).dispatch(specs)
+    script = (tmp_path / "qsub_array.sh").read_text()
+    assert "#$ -t 1-3" in script
+
+
+def test_scc_backend_batch_size_ceil_for_uneven_split(tmp_path):
+    # 7 specs with batch_size=3 → ceil(7/3) = 3 array tasks.
+    specs = _make_specs(tmp_path, n=7)
+    SCCArrayBackend(batch_size=3).dispatch(specs)
+    script = (tmp_path / "qsub_array.sh").read_text()
+    assert "#$ -t 1-3" in script
+
+
+def test_scc_backend_batch_size_in_script_body(tmp_path):
+    specs = _make_specs(tmp_path, n=4)
+    SCCArrayBackend(batch_size=2).dispatch(specs)
+    script = (tmp_path / "qsub_array.sh").read_text()
+    assert "BATCH_SIZE=2" in script
+    assert "for ROW in $(seq" in script
+
+
+def test_scc_backend_manifest_still_one_row_per_spec_with_batching(tmp_path):
+    # Batching affects the script only; the manifest always has one row per spec.
+    specs = _make_specs(tmp_path, n=6)
+    SCCArrayBackend(batch_size=2).dispatch(specs)
+    lines = (tmp_path / "manifest.tsv").read_text().splitlines()
+    assert len(lines) == 1 + 6  # header + 6 data rows
+
+
 # ---------------------------------------------------------------------------
 # LocalParallelBackend — failure handling
 # ---------------------------------------------------------------------------

--- a/tests/test_runner_backends.py
+++ b/tests/test_runner_backends.py
@@ -1,0 +1,319 @@
+"""Tests for the sweep orchestration layer: backends, enumeration, and aggregation.
+
+Fast tests (no subprocess / no JAX warm-up)
+--------------------------------------------
+- ``test_enumerate_sweep_*``   — pure Cartesian-product logic
+- ``test_n_seeds_expansion_*`` — seed shorthand expansion
+- ``test_scc_backend_*``       — script/manifest generation (no qsub)
+- ``test_aggregate_sweep_*``   — reads hand-crafted JSON fixtures
+
+Integration tests (gated behind SABI_BACKENDS_INTEGRATION=1)
+-------------------------------------------------------------
+- ``test_local_sequential_trivial_sweep``
+- ``test_local_parallel_matches_sequential``
+
+These integration tests invoke ``python -m sabi.runner`` as subprocesses,
+so they pay JAX startup overhead (~10–30 s on a cold machine).  Gate them
+in CI with:
+
+    SABI_BACKENDS_INTEGRATION=1 scripts/python -m pytest tests/test_runner_backends.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from sabi.runner.backends import (
+    LocalParallelBackend,
+    LocalSequentialBackend,
+    RunSpec,
+    SCCArrayBackend,
+)
+from sabi.runner.sweep import aggregate_sweep, enumerate_sweep
+
+_INTEGRATION = pytest.mark.skipif(
+    not os.environ.get("SABI_BACKENDS_INTEGRATION"),
+    reason="set SABI_BACKENDS_INTEGRATION=1 to run backend integration tests",
+)
+
+# ---------------------------------------------------------------------------
+# enumerate_sweep
+# ---------------------------------------------------------------------------
+
+
+def test_enumerate_sweep_cartesian_product(tmp_path):
+    specs = enumerate_sweep(["problem=a,b", "seed=0,1"], tmp_path)
+    assert len(specs) == 4
+    combos = {s.overrides for s in specs}
+    assert ("problem=a", "seed=0") in combos
+    assert ("problem=a", "seed=1") in combos
+    assert ("problem=b", "seed=0") in combos
+    assert ("problem=b", "seed=1") in combos
+
+
+def test_enumerate_sweep_single_value_is_constant(tmp_path):
+    specs = enumerate_sweep(["problem=gaussian_2d", "seed=0,1"], tmp_path)
+    assert len(specs) == 2
+    assert all("problem=gaussian_2d" in s.overrides for s in specs)
+
+
+def test_enumerate_sweep_output_dirs_are_unique(tmp_path):
+    specs = enumerate_sweep(["problem=a,b", "seed=0,1"], tmp_path)
+    dirs = [s.output_dir for s in specs]
+    assert len(dirs) == len(set(dirs))
+
+
+def test_enumerate_sweep_output_dirs_under_sweep_dir(tmp_path):
+    specs = enumerate_sweep(["problem=a,b"], tmp_path)
+    for spec in specs:
+        assert spec.output_dir.parent == tmp_path
+
+
+def test_enumerate_sweep_missing_equals_raises(tmp_path):
+    with pytest.raises(ValueError, match="no '=' separator"):
+        enumerate_sweep(["problem"], tmp_path)
+
+
+def test_enumerate_sweep_empty_overrides(tmp_path):
+    # No overrides → one spec with empty overrides (the "null sweep").
+    specs = enumerate_sweep([], tmp_path)
+    assert len(specs) == 1
+    assert specs[0].overrides == ()
+
+
+# ---------------------------------------------------------------------------
+# --n-seeds expansion
+# ---------------------------------------------------------------------------
+
+
+def test_n_seeds_expansion_count(tmp_path):
+    specs = enumerate_sweep(["problem=a,b"], tmp_path, n_seeds=50)
+    assert len(specs) == 100  # 2 problems × 50 seeds
+
+
+def test_n_seeds_expansion_seed_range(tmp_path):
+    specs = enumerate_sweep(["problem=a"], tmp_path, n_seeds=5)
+    seeds = {int(o.split("=")[1]) for s in specs for o in s.overrides if o.startswith("seed=")}
+    assert seeds == {0, 1, 2, 3, 4}
+
+
+def test_n_seeds_conflicts_with_explicit_seed(tmp_path):
+    with pytest.raises(ValueError, match="Cannot combine"):
+        enumerate_sweep(["seed=0,1"], tmp_path, n_seeds=3)
+
+
+def test_n_seeds_zero_raises(tmp_path):
+    with pytest.raises(ValueError, match="n_seeds must be >= 1"):
+        enumerate_sweep([], tmp_path, n_seeds=0)
+
+
+# ---------------------------------------------------------------------------
+# SCCArrayBackend — script/manifest generation (no qsub required)
+# ---------------------------------------------------------------------------
+
+
+def _make_specs(sweep_dir: Path, n: int = 3) -> list[RunSpec]:
+    return [
+        RunSpec(
+            overrides=(f"problem=gaussian_2d", f"seed={i}"),
+            output_dir=sweep_dir / f"run_{i}",
+        )
+        for i in range(n)
+    ]
+
+
+def test_scc_backend_creates_manifest(tmp_path):
+    specs = _make_specs(tmp_path)
+    SCCArrayBackend().dispatch(specs)
+    manifest = tmp_path / "manifest.tsv"
+    assert manifest.exists()
+    lines = manifest.read_text().splitlines()
+    assert lines[0] == "task_id\toutput_dir\toverrides"
+    assert len(lines) == 1 + len(specs)  # header + data rows
+
+
+def test_scc_backend_creates_qsub_script(tmp_path):
+    specs = _make_specs(tmp_path, n=3)
+    SCCArrayBackend().dispatch(specs)
+    script = (tmp_path / "qsub_array.sh").read_text()
+    assert "#$ -t 1-3" in script
+    assert "python -m sabi.runner" in script
+
+
+def test_scc_backend_script_array_size_matches_specs(tmp_path):
+    n = 7
+    specs = _make_specs(tmp_path, n=n)
+    SCCArrayBackend().dispatch(specs)
+    script = (tmp_path / "qsub_array.sh").read_text()
+    assert f"#$ -t 1-{n}" in script
+
+
+def test_scc_backend_manifest_task_ids_sequential(tmp_path):
+    specs = _make_specs(tmp_path, n=4)
+    SCCArrayBackend().dispatch(specs)
+    lines = (tmp_path / "manifest.tsv").read_text().splitlines()[1:]  # skip header
+    task_ids = [int(line.split("\t")[0]) for line in lines]
+    assert task_ids == list(range(1, 5))
+
+
+def test_scc_backend_custom_knobs_reflected_in_script(tmp_path):
+    specs = _make_specs(tmp_path, n=2)
+    backend = SCCArrayBackend(
+        cores=8,
+        mem_gb=32,
+        walltime="04:00:00",
+        queue="gpu_scc",
+        modules=("python3/3.12.3", "cuda/12.2"),
+    )
+    backend.dispatch(specs)
+    script = (tmp_path / "qsub_array.sh").read_text()
+    assert "#$ -pe omp 8" in script
+    assert "l mem_per_core=4G" in script
+    assert "04:00:00" in script
+    assert "#$ -q gpu_scc" in script
+    assert "module load python3/3.12.3" in script
+    assert "module load cuda/12.2" in script
+
+
+def test_scc_backend_logs_dir_created(tmp_path):
+    specs = _make_specs(tmp_path, n=2)
+    SCCArrayBackend().dispatch(specs)
+    assert (tmp_path / "logs").is_dir()
+
+
+def test_scc_backend_empty_specs_is_noop(tmp_path):
+    SCCArrayBackend().dispatch([])
+    assert not (tmp_path / "manifest.tsv").exists()
+
+
+# ---------------------------------------------------------------------------
+# aggregate_sweep — reads hand-crafted JSON fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_fake_run(run_dir: Path, seed: int, problem: str = "gaussian") -> None:
+    run_dir.mkdir(parents=True)
+    summary = {
+        "problem": problem,
+        "n_evals_final": 20,
+        "final_metrics": {"mmd2": 0.01 + seed * 0.001},
+        "tempering_states": [],
+    }
+    (run_dir / "summary.json").write_text(json.dumps(summary))
+    metrics_rows = [
+        json.dumps({"round": r, "mmd2": 0.05 - r * 0.005}) for r in range(3)
+    ]
+    (run_dir / "metrics.jsonl").write_text("\n".join(metrics_rows))
+    # Minimal config.yaml so aggregate_sweep can read seed/problem/etc.
+    config_yaml = f"seed: {seed}\nproblem:\n  name: {problem}\nemulator:\n  name: gp\nacquisition:\n  name: ei\n"
+    (run_dir / "config.yaml").write_text(config_yaml)
+
+
+def test_aggregate_sweep_row_count(tmp_path):
+    for i in range(4):
+        _write_fake_run(tmp_path / f"run_{i}", seed=i)
+    table = aggregate_sweep(tmp_path)
+    assert len(table) == 4
+
+
+def test_aggregate_sweep_writes_parquet(tmp_path):
+    _write_fake_run(tmp_path / "run_0", seed=0)
+    aggregate_sweep(tmp_path)
+    assert (tmp_path / "sweep_results.parquet").exists()
+
+
+def test_aggregate_sweep_columns_include_seed_and_metrics(tmp_path):
+    _write_fake_run(tmp_path / "run_0", seed=42)
+    table = aggregate_sweep(tmp_path)
+    assert "seed" in table.schema.names
+    assert "final_mmd2" in table.schema.names
+
+
+def test_aggregate_sweep_seed_values_round_trip(tmp_path):
+    for seed in (7, 13):
+        _write_fake_run(tmp_path / f"run_{seed}", seed=seed)
+    table = aggregate_sweep(tmp_path)
+    seeds = sorted(table.column("seed").to_pylist())
+    assert seeds == [7, 13]
+
+
+def test_aggregate_sweep_empty_dir_raises(tmp_path):
+    with pytest.raises(ValueError, match="No completed runs"):
+        aggregate_sweep(tmp_path)
+
+
+def test_aggregate_sweep_skips_dirs_without_summary(tmp_path):
+    _write_fake_run(tmp_path / "run_0", seed=0)
+    (tmp_path / "not_a_run").mkdir()  # no summary.json
+    table = aggregate_sweep(tmp_path)
+    assert len(table) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — actual subprocess execution (slow, opt-in)
+# ---------------------------------------------------------------------------
+
+# Tiny config: 4 initial points, 1 round, prior-sampling acquisition, no metrics.
+# Keeps JAX work minimal while exercising the full subprocess path.
+_TINY_OVERRIDES_TEMPLATE = (
+    "algorithm.n_initial=4",
+    "algorithm.n_rounds=1",
+    "acquisition=prior_sampling",
+    "metrics=[]",
+)
+
+
+@_INTEGRATION
+def test_local_sequential_trivial_sweep(tmp_path):
+    specs = [
+        RunSpec(
+            overrides=(*_TINY_OVERRIDES_TEMPLATE, f"seed={i}"),
+            output_dir=tmp_path / f"run_{i}",
+        )
+        for i in range(2)
+    ]
+    LocalSequentialBackend().dispatch(specs)
+    for spec in specs:
+        assert (spec.output_dir / "summary.json").exists()
+        assert (spec.output_dir / "metrics.jsonl").exists()
+
+
+@_INTEGRATION
+def test_local_parallel_trivial_sweep(tmp_path):
+    specs = [
+        RunSpec(
+            overrides=(*_TINY_OVERRIDES_TEMPLATE, f"seed={i}"),
+            output_dir=tmp_path / f"run_{i}",
+        )
+        for i in range(2)
+    ]
+    LocalParallelBackend(n_workers=2).dispatch(specs)
+    for spec in specs:
+        assert (spec.output_dir / "summary.json").exists()
+        assert (spec.output_dir / "metrics.jsonl").exists()
+
+
+@_INTEGRATION
+def test_sequential_and_parallel_produce_same_outputs(tmp_path):
+    """Same seed → same summary regardless of dispatch backend."""
+    seed = 99
+    overrides = (*_TINY_OVERRIDES_TEMPLATE, f"seed={seed}")
+
+    seq_dir = tmp_path / "sequential"
+    par_dir = tmp_path / "parallel"
+
+    LocalSequentialBackend().dispatch(
+        [RunSpec(overrides=overrides, output_dir=seq_dir)]
+    )
+    LocalParallelBackend(n_workers=1).dispatch(
+        [RunSpec(overrides=overrides, output_dir=par_dir)]
+    )
+
+    seq_summary = json.loads((seq_dir / "summary.json").read_text())
+    par_summary = json.loads((par_dir / "summary.json").read_text())
+    assert seq_summary["n_evals_final"] == par_summary["n_evals_final"]
+    assert seq_summary["problem"] == par_summary["problem"]

--- a/tests/test_runner_backends.py
+++ b/tests/test_runner_backends.py
@@ -223,6 +223,68 @@ def test_scc_backend_manifest_still_one_row_per_spec_with_batching(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# SCCArrayBackend — group_by_experiment
+# ---------------------------------------------------------------------------
+
+
+def _make_grouped_specs(sweep_dir: Path) -> list[RunSpec]:
+    """2 problems × 3 seeds = 6 specs; used to test experiment grouping."""
+    return [
+        RunSpec(
+            overrides=(f"problem={p}", f"seed={s}"),
+            output_dir=sweep_dir / f"problem-{p}_seed-{s}",
+        )
+        for p in ("gaussian_2d", "banana")
+        for s in (0, 1, 2)
+    ]
+
+
+def test_group_by_experiment_array_size(tmp_path):
+    # 2 experiments × 3 seeds → 2 array tasks.
+    specs = _make_grouped_specs(tmp_path)
+    SCCArrayBackend(group_by_experiment=True).dispatch(specs)
+    script = (tmp_path / "qsub_array.sh").read_text()
+    assert "#$ -t 1-2" in script
+
+
+def test_group_by_experiment_writes_groups_file(tmp_path):
+    specs = _make_grouped_specs(tmp_path)
+    SCCArrayBackend(group_by_experiment=True).dispatch(specs)
+    groups_path = tmp_path / "groups.tsv"
+    assert groups_path.exists()
+    lines = groups_path.read_text().splitlines()
+    assert lines[0] == "task_id\tstart_row\tend_row"
+    assert len(lines) == 3  # header + 2 groups
+
+
+def test_group_by_experiment_groups_cover_all_rows(tmp_path):
+    specs = _make_grouped_specs(tmp_path)  # 6 specs total
+    SCCArrayBackend(group_by_experiment=True).dispatch(specs)
+    groups_lines = (tmp_path / "groups.tsv").read_text().splitlines()[1:]
+    row_counts = sum(
+        int(line.split("\t")[2]) - int(line.split("\t")[1]) + 1
+        for line in groups_lines
+    )
+    assert row_counts == 6
+
+
+def test_group_by_experiment_script_uses_groups_file(tmp_path):
+    specs = _make_grouped_specs(tmp_path)
+    SCCArrayBackend(group_by_experiment=True).dispatch(specs)
+    script = (tmp_path / "qsub_array.sh").read_text()
+    assert "groups.tsv" in script
+    assert "for ROW in $(seq" in script
+
+
+def test_group_by_experiment_manifest_unchanged(tmp_path):
+    # Manifest always has one row per spec regardless of grouping.
+    specs = _make_grouped_specs(tmp_path)  # 6 specs
+    SCCArrayBackend(group_by_experiment=True).dispatch(specs)
+    lines = (tmp_path / "manifest.tsv").read_text().splitlines()
+    assert len(lines) == 1 + 6
+
+
+# ---------------------------------------------------------------------------
 # LocalParallelBackend — failure handling
 # ---------------------------------------------------------------------------
 

--- a/tests/test_runner_backends.py
+++ b/tests/test_runner_backends.py
@@ -191,6 +191,30 @@ def test_scc_backend_empty_specs_is_noop(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# LocalParallelBackend — failure handling
+# ---------------------------------------------------------------------------
+
+
+@_INTEGRATION
+def test_local_parallel_all_failures_surfaced(tmp_path):
+    """All subprocess failures must be reported, not just the first."""
+    # Specs with an unknown problem name exit non-zero immediately after
+    # Hydra resolves config (before any JAX compute).
+    bad_specs = [
+        RunSpec(
+            overrides=("problem=__nonexistent__",),
+            output_dir=tmp_path / f"bad_{i}",
+        )
+        for i in range(3)
+    ]
+    with pytest.raises(RuntimeError) as exc_info:
+        LocalParallelBackend(n_workers=3).dispatch(bad_specs)
+
+    msg = str(exc_info.value)
+    assert "3 of 3 runs failed" in msg
+
+
+# ---------------------------------------------------------------------------
 # aggregate_sweep — reads hand-crafted JSON fixtures
 # ---------------------------------------------------------------------------
 

--- a/tests/test_runner_backends.py
+++ b/tests/test_runner_backends.py
@@ -251,50 +251,83 @@ def test_local_parallel_all_failures_surfaced(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _write_fake_run(run_dir: Path, seed: int, problem: str = "gaussian") -> None:
-    run_dir.mkdir(parents=True)
-    summary = {
-        "problem": problem,
-        "n_evals_final": 20,
-        "final_metrics": {"mmd2": 0.01 + seed * 0.001},
-        "tempering_states": [],
-    }
-    (run_dir / "summary.json").write_text(json.dumps(summary))
-    metrics_rows = [
-        json.dumps({"round": r, "mmd2": 0.05 - r * 0.005}) for r in range(3)
-    ]
-    (run_dir / "metrics.jsonl").write_text("\n".join(metrics_rows))
-    # Minimal config.yaml so aggregate_sweep can read seed/problem/etc.
-    config_yaml = f"seed: {seed}\nproblem:\n  name: {problem}\nemulator:\n  name: gp\nacquisition:\n  name: ei\n"
-    (run_dir / "config.yaml").write_text(config_yaml)
+def _write_fake_sweep(
+    sweep_dir: Path,
+    runs: list[dict],
+) -> None:
+    """Write a fake completed sweep under *sweep_dir*.
+
+    Parameters
+    ----------
+    runs:
+        Each dict must have ``seed`` (int) and may have ``problem`` (str) and
+        arbitrary extra override keys (e.g. ``algorithm.n_rounds``).  A
+        subdirectory ``run_<seed>`` is created for each entry.
+    """
+    # Write manifest.tsv
+    with (sweep_dir / "manifest.tsv").open("w") as mf:
+        mf.write("task_id\toutput_dir\toverrides\n")
+        for i, run in enumerate(runs, start=1):
+            run_dir = sweep_dir / f"run_{run['seed']}"
+            overrides = " ".join(f"{k}={v}" for k, v in run.items())
+            mf.write(f"{i}\t{run_dir}\t{overrides}\n")
+
+    # Write per-run files
+    for run in runs:
+        seed = run["seed"]
+        problem = run.get("problem", "gaussian")
+        run_dir = sweep_dir / f"run_{seed}"
+        run_dir.mkdir(parents=True)
+        summary = {
+            "problem": problem,
+            "n_evals_final": 20,
+            "final_metrics": {"mmd2": 0.01 + seed * 0.001},
+            "tempering_states": [],
+        }
+        (run_dir / "summary.json").write_text(json.dumps(summary))
+        metrics_rows = [
+            json.dumps({"round": r, "mmd2": 0.05 - r * 0.005}) for r in range(3)
+        ]
+        (run_dir / "metrics.jsonl").write_text("\n".join(metrics_rows))
 
 
 def test_aggregate_sweep_row_count(tmp_path):
-    for i in range(4):
-        _write_fake_run(tmp_path / f"run_{i}", seed=i)
+    _write_fake_sweep(tmp_path, [{"seed": i} for i in range(4)])
     table = aggregate_sweep(tmp_path)
     assert len(table) == 4
 
 
 def test_aggregate_sweep_writes_parquet(tmp_path):
-    _write_fake_run(tmp_path / "run_0", seed=0)
+    _write_fake_sweep(tmp_path, [{"seed": 0}])
     aggregate_sweep(tmp_path)
     assert (tmp_path / "sweep_results.parquet").exists()
 
 
 def test_aggregate_sweep_columns_include_seed_and_metrics(tmp_path):
-    _write_fake_run(tmp_path / "run_0", seed=42)
+    _write_fake_sweep(tmp_path, [{"seed": 42}])
     table = aggregate_sweep(tmp_path)
     assert "seed" in table.schema.names
     assert "final_mmd2" in table.schema.names
 
 
 def test_aggregate_sweep_seed_values_round_trip(tmp_path):
-    for seed in (7, 13):
-        _write_fake_run(tmp_path / f"run_{seed}", seed=seed)
+    _write_fake_sweep(tmp_path, [{"seed": 7}, {"seed": 13}])
     table = aggregate_sweep(tmp_path)
     seeds = sorted(table.column("seed").to_pylist())
     assert seeds == [7, 13]
+
+
+def test_aggregate_sweep_nested_override_becomes_column(tmp_path):
+    # Nested overrides like algorithm.n_rounds should appear as columns
+    # when a manifest is present — this was not possible with config.yaml only.
+    _write_fake_sweep(
+        tmp_path,
+        [{"seed": 0, "algorithm.n_rounds": 5}, {"seed": 1, "algorithm.n_rounds": 10}],
+    )
+    table = aggregate_sweep(tmp_path)
+    assert "algorithm.n_rounds" in table.schema.names
+    rounds = sorted(table.column("algorithm.n_rounds").to_pylist())
+    assert rounds == [5, 10]
 
 
 def test_aggregate_sweep_empty_dir_raises(tmp_path):
@@ -303,8 +336,19 @@ def test_aggregate_sweep_empty_dir_raises(tmp_path):
 
 
 def test_aggregate_sweep_skips_dirs_without_summary(tmp_path):
-    _write_fake_run(tmp_path / "run_0", seed=0)
+    _write_fake_sweep(tmp_path, [{"seed": 0}])
     (tmp_path / "not_a_run").mkdir()  # no summary.json
+    table = aggregate_sweep(tmp_path)
+    assert len(table) == 1
+
+
+def test_aggregate_sweep_no_manifest_still_works(tmp_path):
+    # Falls back gracefully when no manifest.tsv exists (e.g. manually created
+    # run directories) — rows are produced with only summary/metrics columns.
+    run_dir = tmp_path / "run_0"
+    run_dir.mkdir()
+    summary = {"problem": "gaussian", "n_evals_final": 20, "final_metrics": {}}
+    (run_dir / "summary.json").write_text(json.dumps(summary))
     table = aggregate_sweep(tmp_path)
     assert len(table) == 1
 


### PR DESCRIPTION
Closes #16.

## Summary

- Adds `RunSpec` + `RunBackend` ABC with three concrete backends: `LocalSequentialBackend`, `LocalParallelBackend` (stdlib `ProcessPoolExecutor`), and `SCCArrayBackend` (SGE/qsub script generation)
- All backends dispatch via `python -m sabi.runner <overrides>` subprocesses, so local ↔ cluster parity is exact
- `enumerate_sweep()` expands Hydra-style comma-separated overrides into the Cartesian product of `RunSpec` objects; `--n-seeds N` auto-generates `seed=0,1,...,N-1` for large replicate counts
- `aggregate_sweep()` walks a completed sweep directory and returns a tidy `pyarrow.Table` (also writes `sweep_results.parquet`)
- `sabi-submit` and `sabi-aggregate` CLI entry points wired via `[project.scripts]`
- Reference backend config templates added under `configs/backend/`

## Test plan

- [ ] 23 fast tests (sweep enumeration, SCC script/manifest generation, aggregation) pass unconditionally: `scripts/python -m pytest tests/test_runner_backends.py -v`
- [ ] 3 integration tests (actual subprocess runs) opt-in via `SABI_BACKENDS_INTEGRATION=1`
- [ ] Full suite: 315 passed, 0 failures

## Notes

- `SCCArrayBackend.dispatch()` writes `manifest.tsv` + `qsub_array.sh` but does not submit — user runs `qsub qsub_array.sh` manually
- Documentation page for backends deferred until PR #47 (docs standards) merges