### PR TITLE
docs(design): propose link functions + bridging refactor (#55)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ into [ProbPipe](https://github.com/arob5/prob-pipe).
 - **Concepts** — the design notes that have shaped the library:
   {doc}`design <design>`, {doc}`notation <notation>`,
   {doc}`emulators <emulators>`, {doc}`tempering <tempering>`,
+  {doc}`link functions <link_functions>`,
   {doc}`scheduled metrics <scheduled_metrics>`.
 - **API reference** — auto-generated from the `sabi.*` source tree; rendered
   docstrings include the math.
@@ -40,6 +41,7 @@ design
 notation
 emulators
 tempering
+link_functions
 scheduled_metrics
 v1_plan
 probpipe_random_measure_proposal

--- a/docs/link_functions.md
+++ b/docs/link_functions.md
@@ -350,27 +350,32 @@ and is orthogonal to which layer is queried.
 
 ### 6.2 Axis 2: which predictive layer to target
 
-New axis, surfaced by the `Map`-dispatch design. A `SurrogateDistribution`
-exposes layered predictives by composing different Maps on top of the
-emulator predictive:
+New axis, surfaced by the `Map`-dispatch design. The three layers map to
+ProbPipe primitives that already exist (or compose trivially from ones that
+do), so no new sabi-side methods are needed:
 
-```python
-class SurrogateDistribution:
-    def emulator_predictive_at(self, x) -> Distribution:
-        """Raw emulator predictive (the y distribution itself)."""
-        return self._emulator(x)
+| Layer | Op | What it returns |
+|-------|-----|-----------------|
+| Emulator (raw $y$) | `surr_dist.emulator(X)` | `Distribution[Array]` over $y$ — the emulator predictive at $X$. |
+| Unnormalised log-density | `random_unnormalized_log_prob(surr_dist, X)` | `Distribution[Array]` over $\log\tilde p(X)$ — what `EmulatedDistribution` exposes via `_random_unnormalized_log_prob`. |
+| Unnormalised density | `pushforward(Exp(), random_unnormalized_log_prob(surr_dist, X))` | `Distribution[Array]` over $\tilde p(X)$. |
 
-    def log_density_predictive_at(self, x) -> Distribution:
-        """Pushed through the form: log-density distribution at x."""
-        return self._form.pushforward(x, self._emulator(x))
+`EmulatedDistribution` exposes `emulator` as a property (so callers can
+write `surr_dist.emulator(X)` to get the raw predictive) and implements
+`_random_unnormalized_log_prob() -> RandomFunction` (per ProbPipe's
+`SupportsRandomUnnormalizedLogProb`); the `RandomFunction` returned
+pushes the emulator predictive through `form.pushforward` under the
+hood. Both the deterministic and random log-density paths converge here:
+`unnormalized_log_prob(target_dist, x)` and
+`random_unnormalized_log_prob(surr_dist, X)` are the non-random and
+random analogues of the same quantity.
 
-    def density_predictive_at(self, x) -> Distribution:
-        """Pushed through the form, then exp'd: density distribution at x."""
-        return pushforward(Exp(), self.log_density_predictive_at(x))
-```
-
-Each layer is a separate `Distribution`, accessed via a different `Map`
-composition. Acquisitions pick the layer they want.
+The density layer falls out of `Exp` map composition: `pushforward(Exp(),
+log_density_dist)` is the (random) unnormalised density. ProbPipe could
+later add a `random_unnormalized_prob` op as the analogue of its existing
+deterministic `unnormalized_prob` (which is `exp(unnormalized_log_prob)`);
+sabi's pushforward composition gives the same result without waiting on
+that op.
 
 ### 6.3 Acquisition example
 
@@ -380,11 +385,14 @@ class MaxVariance(Acquisition):
     target_intermediate: AcquisitionTarget = AcquisitionTarget.CURRENT
     target_layer: PredictiveLayer = PredictiveLayer.LOG_DENSITY
 
-    def acquire(self, sp: SurrogateDistribution, X_candidate) -> Array:
+    def acquire(self, surr_dist: SurrogateDistribution, X_candidate) -> Array:
         match self.target_layer:
-            case PredictiveLayer.EMULATOR:    pred = sp.emulator_predictive_at(X_candidate)
-            case PredictiveLayer.LOG_DENSITY: pred = sp.log_density_predictive_at(X_candidate)
-            case PredictiveLayer.DENSITY:     pred = sp.density_predictive_at(X_candidate)
+            case PredictiveLayer.EMULATOR:
+                pred = surr_dist.emulator(X_candidate)
+            case PredictiveLayer.LOG_DENSITY:
+                pred = random_unnormalized_log_prob(surr_dist, X_candidate)
+            case PredictiveLayer.DENSITY:
+                pred = pushforward(Exp(), random_unnormalized_log_prob(surr_dist, X_candidate))
         return variance(pred)
 ```
 
@@ -594,12 +602,18 @@ this is now a materially larger refactor than the original issue scoped.
    shape. The closed-form pushforward for `(Affine, Normal | MVN)`
    makes `_shift_gaussian_loc` redundant; remove. `pushforward_marginal`
    becomes a thin wrapper around `form.pushforward(x, y)`.
-4. **Phase 4 — surrogate layered predictive access** (separate
-   issue/PR). Add `SurrogateDistribution.{emulator,log_density,density}_predictive_at`
-   per [§6.2](#62-axis-2-which-predictive-layer-to-target). Audit
-   current acquisitions for layer-access opportunities; introduce
+4. **Phase 4 — acquisition layered access** (separate issue/PR).
+   `EmulatedDistribution` already exposes `emulator` as a property and
+   implements `_random_unnormalized_log_prob` (via the
+   `pushforward_marginal` path that becomes `form.pushforward` after
+   Phase 3). Phase 4's work is acquisition-side: introduce the
    `PredictiveLayer` enum and add `target_layer` parameter to
-   acquisitions that benefit (likely just `MaxVariance` for now).
+   acquisitions that benefit (likely just `MaxVariance` for now), with
+   the dispatch wired to `surr_dist.emulator(X)` /
+   `random_unnormalized_log_prob(surr_dist, X)` /
+   `pushforward(Exp(), random_unnormalized_log_prob(surr_dist, X))`
+   per [§6.2](#62-axis-2-which-predictive-layer-to-target). No new
+   methods on `SurrogateDistribution`.
 5. **Phase 5 — bridging rename + collapse** (separate issue/PR).
    `sabi.tempering` → `sabi.bridging`; `TemperingScheme` →
    `BridgingScheme`; per-form-type `_*Tempered` classes collapse into

--- a/docs/link_functions.md
+++ b/docs/link_functions.md
@@ -1,347 +1,335 @@
-# Link functions and bridging — design proposal
+# Form abstraction refactor — `DensityForm`, `Map`, and bridging
 
-**Status:** draft v0.2 — pre-implementation
+**Status:** draft v0.3 — pre-implementation
 **Issue:** [#55](https://github.com/arob5/sabi/issues/55)
-**Last updated:** 2026-05-06
+**Last updated:** 2026-05-07
 
-> Proposal for two coupled refactors:
+> Two coupled refactors, motivated by issue #55:
 >
-> 1. Generalise sabi's emulated quantity beyond log-density. Today every
->    `LogDensityForm` returns an unnormalised log-posterior, with `density ∝
->    exp(form_output)` applied implicitly downstream. We replace this with an
->    explicit **link function** abstraction: `density ∝ link(g(x))` for `link
->    ∈ {exp, softplus, square, …}`.
-> 2. Reframe `TemperingScheme` as `BridgingScheme` — the operative concept is a
->    *family of intermediate distributions between an initial and target
->    distribution*, of which likelihood tempering is one instance. Several
->    redundant abstractions collapse under this framing.
+> 1. **Form unification.** Collapse today's `LogDensityForm` hierarchy
+>    (`Identity`, `LogLikPlusPrior`, `ForwardModel`) into a single
+>    `DensityForm` parameterised by a `Map` (the link from emulator output
+>    to log-density-residual) plus an additive `Map` shift (the
+>    deterministic x-dependent term, typically a log-prior). Specific forms
+>    — including alternative link functions like softplus and square —
+>    become `Map` compositions, not subclasses.
+> 2. **Bridging rename and reshape.** `TemperingScheme` becomes
+>    `BridgingScheme`. Likelihood tempering is one bridge family among
+>    several future ones; bridges operate on a `DensityForm` by composing
+>    `Map`s on its `link` and `shift`.
 >
-> The two refactors are coupled because the bridge's interaction with non-exp
-> links surfaces dispatch decisions that didn't exist before (e.g.,
-> "via-target-rescale" tempering only works under exp link). Doing them in one
-> design pass avoids re-litigating the form/link API when the bridging
-> rewrite lands.
+> A `pushforward(Map, Distribution) → Distribution` multi-dispatch op
+> handles both deterministic evaluation and pushing emulator predictives
+> through forms. The `Map` abstraction is intentionally aligned with what
+> ProbPipe is converging on; sabi's local op becomes a re-export when
+> ProbPipe lands.
 >
-> This is a **design-only** PR: no source code changes. Implementation is split
-> across follow-up issues (see [§9](#9-phasing-and-follow-up-issues)).
+> This is a **design-only** PR: no source code changes. Implementation is
+> split across follow-up issues (see [§9](#9-phasing-and-follow-up-issues)).
 >
 > Sabi's API is not yet stable; this proposal does not preserve back-compat
 > with current names or signatures.
 
 ## 1. Motivation
 
-The exponential link is the default not because it is best, but because it is
-implicit. Every form in
-[`src/sabi/problems/forms.py`](../src/sabi/problems/forms.py) returns a value
-$g(x)$ that is interpreted as $\log p(x)$, and the consumer (ProbPipe MCMC,
-`Weights.log_weights` softmax) applies $\exp$ to recover an unnormalised
-density. Sabi never calls `exp` itself — but the assumption is everywhere.
+The current `LogDensityForm` hierarchy treats three instances of the same
+abstraction as separate classes:
 
-The exp link has well-known instabilities:
+- `Identity._call_single(x, y) = y` — the emulator emits log-density; the
+  form is the identity function.
+- `LogLikPlusPrior._call_single(x, y) = y + log_prior(x)` — the emulator
+  emits log-likelihood; the form adds the log-prior.
+- `ForwardModel._call_single(x, y) = log_lik_from_outputs(x, y) +
+  log_prior(x)` — the emulator emits a forward-model output; the form
+  applies a user-supplied likelihood and adds the log-prior.
 
-- **Tail blow-up.** Small perturbations in the emulator's mean translate to
-  multiplicative blow-up in density when $\log p$ is large. A GP uncertainty
-  band of $\pm 2$ around $\log p = 30$ is densities differing by $e^4 \approx
-  55\times$.
-- **Pushforward variance.** Pushing a Gaussian through `exp` gives a log-normal
-  whose mean and variance are dominated by the upper tail of the Gaussian. The
-  bias note in
-  [`src/sabi/surrogate/estimators.py:15`](../src/sabi/surrogate/estimators.py)
-  is a direct symptom: the plug-in mean estimator is biased because of exactly
-  this tail-domination.
-- **Acquisition behaviour.** Acquisitions that integrate the surrogate against
-  a posterior weight inherit the same tail sensitivity.
-- **GP fitting.** Log-densities span huge dynamic range — often hundreds of
-  nats. A stationary-kernel GP struggles to fit a function ranging over
-  $[-300, 0]$ with sharp falloff. Output-scaling helps with the symptom; the
-  underlying issue (`exp` couples small fitting errors to large density errors)
-  remains.
+All three are instances of "the emulator emits $y$ at $x$, and a function
+$\Phi(x, y) \mapsto \log p(x)$ assembles the log-density." `ForwardModel`
+in particular is *already* a general "link function" implementation — its
+`log_lik_from_outputs` callback can be any mapping from emulator output to
+log-likelihood, including a Gaussian density
+$\log\mathcal{N}(\mathrm{obs} \mid f(x), C)$, a Student-$t$ density, or
+anything else — but the abstraction's name advertises it as forward-model
+specific. Adding alternative link functions to `LogLikPlusPrior` (issue
+#55's original framing) means either patching the class with a `link`
+field or adding new sibling classes; both fight the underlying structure.
 
-Alternative links (softplus, square) preserve non-negativity of density while
-giving the emulated quantity a more compact range. The motivation for the
-abstraction is thus narrow: **let the user choose what quantity the emulator
-fits, with `log-likelihood` (the current default, exp link) as one option
-among several**.
+The structural fix is to collapse the hierarchy. Define `DensityForm` as a
+thin combination of:
+
+- a `Map` `link: y \mapsto z` (the emulator-output side; ranges from the
+  identity to a Gaussian log-likelihood),
+- a `Map` `shift: x \mapsto z'` (the deterministic x-dependent additive
+  term, typically a log-prior),
+- a `Constraint` on $y$.
+
+Specific forms become specific `Map` choices. Alternative link functions
+are concrete `Map` subclasses (`Softplus`, `LogSoftplus`, `Square`, …)
+that slot in. Forward-model emulation is a `Map` choice
+(`GaussianLogLik`). Tempering is `Map` composition on a base form's
+`link`. The downstream pushforward / estimator / acquisition machinery
+dispatches on `Map` types, not on form subclasses.
+
+The exponential link is no longer privileged — under this design, the
+default form for log-density emulation is `DensityForm(link=Identity())`;
+log-likelihood-plus-prior under exp link is `DensityForm(link=Identity(),
+shift=LogProb(prior))`; under softplus link, `DensityForm(link=LogSoftplus(),
+shift=LogProb(prior))`. The codepath is the same in all three cases.
 
 ## 2. Current state map
 
-The implicit-exp assumption is baked into the following sites. Any link
-abstraction must intercept all of them.
+The form hierarchy and its consumers:
 
-| Site | What it does | Why it's exp-bound |
-|------|--------------|---------------------|
-| [`src/sabi/problems/forms.py`](../src/sabi/problems/forms.py) | `LogDensityForm` family — `Identity`, `LogLikPlusPrior`, `ForwardModel` | Return value is documented as "unnormalised log-posterior". |
-| [`src/sabi/surrogate/_pushforward.py:79`](../src/sabi/surrogate/_pushforward.py) | `pushforward_marginal` Gaussian-affine closed form | Closed form preserves Gaussianity by shifting `loc`; only valid because the form is *additive* in log-density space. |
-| [`src/sabi/surrogate/estimators.py:129`](../src/sabi/surrogate/estimators.py) | `_ExpectedTargetDistribution._unnormalized_log_prob` plug-in mean | Plugs emulator's predictive mean into form, treats result as log-density. |
-| [`src/sabi/surrogate/weighted_empirical.py:64`](../src/sabi/surrogate/weighted_empirical.py) | `WeightedEmpiricalRandomMeasure` log-weights | Weights consumed via softmax in ProbPipe `Weights` — assumes log-space input. |
-| [`src/sabi/target_distribution.py:56`](../src/sabi/target_distribution.py) | `TargetDistribution._unnormalized_log_prob` | ProbPipe `SupportsUnnormalizedLogProb` boundary — MCMC expects log-density. |
-| [`src/sabi/tempering/likelihood.py`](../src/sabi/tempering/likelihood.py) | `_LogLikPlusPriorTempered`, `_ForwardModelTempered`, `_IdentityTempered` | All do `β·log_likelihood_term`; tempering composes additively in log-space (see [§8](#8-bridging)). |
+| Site | What it does |
+|------|--------------|
+| [`src/sabi/problems/forms.py`](../src/sabi/problems/forms.py) | `LogDensityForm` family — `Identity`, `LogLikPlusPrior`, `ForwardModel`. Three classes for one abstraction. |
+| [`src/sabi/surrogate/_pushforward.py:79`](../src/sabi/surrogate/_pushforward.py) | `pushforward_marginal` dispatches on `(input_dist, form_subclass)` for closed-form Gaussian-affine, falls back to MC for everything else. |
+| [`src/sabi/surrogate/_pushforward.py:144`](../src/sabi/surrogate/_pushforward.py) | `_shift_gaussian_loc` — bespoke handling of "shift `loc` by per-point log-prior, leave `scale_tril` alone." Generalises to any `Affine` Map. |
+| [`src/sabi/surrogate/estimators.py:129`](../src/sabi/surrogate/estimators.py) | `_ExpectedTargetDistribution._unnormalized_log_prob` plug-in mean. The bias note at line 15 is a symptom of the existing exp-link composition. |
+| [`src/sabi/surrogate/weighted_empirical.py:64`](../src/sabi/surrogate/weighted_empirical.py) | `WeightedEmpiricalRandomMeasure` log-weights. Form output is converted externally; class is link-agnostic. |
+| [`src/sabi/target_distribution.py:56`](../src/sabi/target_distribution.py) | `TargetDistribution._unnormalized_log_prob` — ProbPipe boundary; consumes log-density. Link-agnostic boundary. |
+| [`src/sabi/tempering/likelihood.py`](../src/sabi/tempering/likelihood.py) | `_LogLikPlusPriorTempered`, `_ForwardModelTempered`, `_IdentityTempered` — three subclasses for one β-scale rewrite. |
 
-The `WeightedEmpiricalRandomMeasure` site is link-agnostic in practice: weights
-are computed *outside* the class via the form, so the class only sees the
-already-converted log-weights. The other five sites all directly compose with
-form output.
+Two things stand out:
 
-## 3. The `Link` abstraction
+- The pushforward / tempering layers branch on form *subclass*. Adding a
+  new link function multiplies this branching. A single `DensityForm` with
+  composable `Map`s collapses the branching into per-Map dispatch.
+- `_shift_gaussian_loc` is a one-off Gaussian-affine pushforward primitive.
+  Generalising to `pushforward(Affine, Normal | MVN)` makes it the first
+  entry in a registry that handles arbitrary `Map`s.
 
-A `Link` is the function $\ell$ that maps the emulator's output $g(x)$ to an
-unnormalised likelihood (or density, depending on the form). It carries two
-methods plus an inverse:
+## 3. The `Map` abstraction
 
-```python
-class Link(ABC):
-    def link(self, g: Array) -> Array: ...        # g → unnormalised lik/density
-    def log_link(self, g: Array) -> Array: ...    # g → log unnormalised lik/density
-                                                  # (numerically stable; not log(link(g)))
-    def inv_link(self, d: Array) -> Array: ...    # unnormalised lik/density → g
-                                                  # (used at construction / reference targets)
-```
-
-The four candidate concrete links:
-
-### 3.1 `ExpLink` — the status quo, in disguise
-
-$$\ell(g) = \exp(g),\quad \log\ell(g) = g,\quad \ell^{-1}(d) = \log(d).$$
-
-The fact that `log_link` is the identity is exactly why the current codebase
-doesn't have to call any link function: the emulator emits $g(x) = \log
-\mathrm{lik}(x)$ directly, and the form returns log-density without applying
-any transformation.
-
-**The most important sentence in this whole document:** under `ExpLink`, *$g$
-is log-likelihood* (or log-posterior, depending on the form). Choosing
-`ExpLink` is equivalent to "the emulator fits log-likelihood / log-posterior",
-which is the common case and the current behaviour.
-
-### 3.2 `SoftplusLink`
-
-$$\ell(g) = \log(1 + e^g),\quad \log\ell(g) = \log\log(1 + e^g),\quad
-\ell^{-1}(d) = \log(e^d - 1).$$
-
-Range: $(0, \infty)$. Behaves like $\exp(g)$ for $g \ll 0$ (preserving
-log-likelihood tail-decay) and like $g$ for $g \gg 0$ (much milder dynamic
-range). Smooth and differentiable everywhere; non-negative without any
-constraint on $g$.
-
-The emulator now fits $g(x) = \mathrm{softplus}^{-1}(\mathrm{lik}(x))$, *not*
-log-likelihood. In the high-density region, $g$ has a compact range; in the
-tails, $g \approx \log\mathrm{lik}$. Tighter GP fits in the high-density
-region are the qualitative argument for softplus.
-
-Pushforward of $\mathcal{N}(\mu, \sigma^2)$: no closed form. Stable
-approximations: Gauss–Hermite quadrature for low-order moments; Monte Carlo
-via the existing MC fallback in `pushforward_marginal`.
-
-### 3.3 `SquareLink`
-
-$$\ell(g) = g^2,\quad \log\ell(g) = 2\log|g|,\quad \ell^{-1}(d) = \sqrt{d}.$$
-
-Range: $[0, \infty)$. Differentiable, but $\log\ell$ has a singularity at
-$g = 0$. Has a clean Hellinger / $L^2$-geometry interpretation and connects
-to the warped-GP literature for non-negative quantities; also appears in
-Bayesian-quadrature work (Osborne et al.).
-
-The emulator fits $g(x) = \sqrt{\mathrm{lik}(x)}$ (with sign).
-
-Pushforward of $\mathcal{N}(\mu, \sigma^2)$ through $g^2$ is a scaled
-non-central chi-squared with one degree of freedom and noncentrality
-parameter $\lambda = (\mu/\sigma)^2$ — closed-form moments and density.
-
-**Sign-convention drawback:** density is invariant under $g \mapsto -g$. The
-emulator's $g$ is identifiable only up to a global sign per disconnected
-support component. Practical implementations pin a sign convention (e.g.
-$g \ge 0$ via a prior or an output transform that absorbs the sign).
-Multimodal posteriors with disconnected high-density regions are a known
-failure mode worth flagging.
-
-### 3.4 `SigmoidLink` (for density ratios)
-
-$$\ell(g) = \sigma(g) = \frac{1}{1 + e^{-g}}.$$
-
-Range $(0, 1)$. Less natural for unnormalised densities (which are unbounded
-above), but fits when sabi is used to emulate a *density ratio* — a
-likelihood relative to a reference, or a posterior relative to the prior —
-where the natural range is bounded. Listed for completeness; the design
-must not preclude it but does not need to ship it in the first cut.
-
-### 3.5 Identity-with-positivity (ruled out)
-
-$\ell(g) = \max(g, 0)$ is non-differentiable at zero, which breaks
-GP-machinery composition. Smooth approximations *are* softplus and square.
-Not pursued.
-
-## 4. The `DensityForm` abstraction
-
-`LogDensityForm` is renamed to `DensityForm` and its base contract reduces
-to:
-
-```python
-class DensityForm(ABC):
-    def _call_single(self, x, y, *, prior) -> Array:
-        """Return the unnormalised log-density at x given emulator output y."""
-```
-
-This is the abstraction in your first requirement: *"an underlying emulator
-and a function that transforms the emulator target to obtain (log)
-unnormalised density."* Every form is "emulator + transformation function";
-the link is one factorisation of the transformation, not a universal field.
-
-Three concrete subclasses, with renaming:
-
-### 4.1 `Identity`
-
-```python
-@dataclass(frozen=True)
-class Identity(DensityForm):
-    """Emulator emits g(x); density(x) ∝ link(g(x)). No prior involvement."""
-    link: Link
-
-    def _call_single(self, x, y, *, prior=None) -> Array:
-        return self.link.log_link(y)
-```
-
-Under `ExpLink`: $g(x) = \log p(x)$, the form returns $y$ unchanged. Same as
-today's `Identity`.
-
-Under `SoftplusLink`: emulator fits $g(x) = \mathrm{softplus}^{-1}(p(x))$;
-form returns $\log\log(1 + e^y)$.
-
-### 4.2 `LikelihoodWithPrior`
-
-(Renamed from `LogLikPlusPrior`.)
-
-```python
-@dataclass(frozen=True)
-class LikelihoodWithPrior(DensityForm):
-    """Emulator emits g(x); likelihood(x) ∝ link(g(x)); density = link(g(x)) · prior(x)."""
-    link: Link
-
-    def _call_single(self, x, y, *, prior) -> Array:
-        return self.link.log_link(y) + log_prob(prior, x)
-```
-
-Under `ExpLink`: $g(x) = \log L(x)$, form returns $y + \log\pi_0(x)$. Same as
-today's `LogLikPlusPrior`.
-
-Under `SoftplusLink`: emulator fits $g(x) = \mathrm{softplus}^{-1}(L(x))$;
-form returns $\log\log(1 + e^y) + \log\pi_0(x)$.
-
-### 4.3 `ForwardModel` (link-free by design)
-
-```python
-@dataclass(frozen=True)
-class ForwardModel(DensityForm):
-    """Emulator emits forward-model output y; user-supplied likelihood does the rest."""
-    log_lik_from_outputs: Callable[[Array, Array], Array]
-
-    def _call_single(self, x, y, *, prior) -> Array:
-        return self.log_lik_from_outputs(x, y) + log_prob(prior, x)
-```
-
-`ForwardModel` does not carry a `Link`. The reason: the emulator's output is a
-forward-model quantity (e.g. simulated observations), not a density-related
-quantity. The user-supplied `log_lik_from_outputs` already absorbs whatever
-likelihood model they want to apply. The link concept describes *"how the
-emulator's output relates to density"* — and for forward-model emulation,
-that mapping lives entirely inside the user's likelihood code.
-
-This is not an awkward exception: `ForwardModel` is still a `DensityForm`
-(satisfies the same `_call_single` contract) and integrates with downstream
-machinery identically. It just doesn't expose a link as a separate axis.
-
-(For users who want to fit a non-log likelihood — e.g. emulate
-$\sqrt{\mathrm{lik}}$ via `ForwardModel` — they write
-`log_lik_from_outputs(x, y) = 2 * log(abs(y))`, doing the link inside their
-code. This is mathematically equivalent to a `LikelihoodWithPrior(SquareLink)`
-where the emulator fits $\sqrt{L}$. The two paths are alternatives, not in
-conflict.)
-
-## 5. Map-based pushforward dispatch
-
-The current `pushforward_marginal(input_dist, form, X, prior)` collapses
-several distinct transformations into one function. To support both
-non-exp links *and* the acquisition flexibility your second requirement asks
-for, we factor the transformations into separate `Map` objects and reify
-pushforward as multiple-dispatch on `(Map, Distribution)`.
-
-This is also the abstraction ProbPipe is converging on for its
-transport-map / pushforward op. By building it locally now, the eventual
-swap to ProbPipe's primitive is a class-rename, not a refactor.
-
-### 5.1 The `Map` abstraction
+A `Map` is a single-variable measurable function with a declared shape
+contract that participates in pushforward dispatch.
 
 ```python
 class Map(ABC):
-    """A measurable function. Pushforwards dispatch on (Map, Distribution) types."""
-    def __call__(self, x: Array) -> Array: ...
+    """Single-variable callable participating in pushforward dispatch."""
+    event_shape_in:  tuple[int, ...]
+    event_shape_out: tuple[int, ...]
+
+    def __call__(self, z: Array) -> Array: ...
+
+    def __matmul__(self, other: Map) -> Map:
+        """Composition: (f @ g)(z) = f(g(z))."""
+        return Compose(self, other)
 ```
 
-Concrete maps for the link / form machinery, named for their mathematical
-content (not their role in sabi):
+### 3.1 Shape contract
 
-| Map | $f(x)$ | Used for |
-|-----|--------|----------|
-| `Identity` | $x$ | `ExpLink.log_link` (the no-op case); identity pushforward |
-| `Log` | $\log x$ | `ExpLink.inv_link`; numerically risky in tails |
-| `Softplus` | $\log(1 + e^x)$ | `SoftplusLink.link` |
-| `LogSoftplus` | $\log\log(1 + e^x)$ | `SoftplusLink.log_link` (numerically stable form) |
-| `Square` | $x^2$ | `SquareLink.link` |
-| `LogSquare` | $2\log|x|$ | `SquareLink.log_link` (numerically stable form) |
-| `Sigmoid`, `LogSigmoid` | $\sigma(x)$, $\log\sigma(x)$ | `SigmoidLink` family |
-| `Affine(a, b)` | $a \cdot x + b$ | scaling + shift; covers "shift loc by log-prior" |
+Inspired by TFP bijectors but stripped — sabi's Maps don't require
+bijectivity, so we don't carry `inverse_min_event_ndims` or
+`log_det_jacobian` slots.
 
-Maps compose via `Compose(f, g)(x) = f(g(x))`. A link's `log_link` method
-returns the appropriate `Map`; the link's `link` method likewise returns a
-density-scale `Map`.
+- `event_shape_in`: shape of one input event. For most form-related Maps,
+  this is `()` (scalar emulator output) or `output_shape` (vector
+  emulator output, e.g. `(d,)` for a forward-model output of dimension
+  $d$).
+- `event_shape_out`: shape of one output event. For form `link`s that
+  produce log-density-residual, this is `()` (scalar). For `shift`s,
+  also `()`.
+- **Broadcasting.** Maps broadcast over leading batch axes; given input
+  of shape `batch_shape + event_shape_in`, the output has shape
+  `batch_shape + event_shape_out`. Same convention as `ArrayRandomFunction`
+  in [`docs/notation.md`](notation.md).
+- **Composition.** `f @ g` requires `f.event_shape_in == g.event_shape_out`.
+  Result: `event_shape_in = g.event_shape_in`,
+  `event_shape_out = f.event_shape_out`.
 
-The "add log-prior to a log-density" operation is *not* a separate map type —
-at fixed query point $x$, it's `Affine(a=1, b=log_prior(x))`. Across a batch
-of query points, it's a per-row `Affine` shift, which is just elementwise
-addition of a `Distribution` with a constant `Array`. ProbPipe will likely
-have a primitive for this (distribution + array → distribution); sabi's
-local stand-in is the existing `_shift_gaussian_loc` in
-[`src/sabi/surrogate/_pushforward.py:144`](../src/sabi/surrogate/_pushforward.py).
+### 3.2 Concrete Maps
 
-### 5.2 The `pushforward` op
+The first cut. Each Map is a small dataclass.
+
+| Map | $f(z)$ | event shapes | Notes |
+|-----|--------|--------------|-------|
+| `Identity` | $z$ | `() → ()` | Closed-form pushforward through any distribution. |
+| `Constant(c)` | $c$ (ignores $z$) | `(any) → c.shape` | Used as default `shift`. |
+| `Affine(slope, intercept)` | $\mathrm{slope} \cdot z + \mathrm{intercept}$ | `() → ()` | Closed-form pushforward through Gaussians. |
+| `Compose(f, g)` | $f(g(z))$ | depends | Built via `f @ g`. |
+| `Exp` | $e^z$ | `() → ()` | Closed form for `(Exp, Normal) → LogNormal`. |
+| `Log` | $\log z$ | `() → ()` | Closed form for `(Log, LogNormal) → Normal`. |
+| `Softplus` | $\log(1 + e^z)$ | `() → ()` | MC fallback for `(Softplus, Normal)`. |
+| `LogSoftplus` | $\log\log(1 + e^z)$ (numerically stable) | `() → ()` | MC fallback. |
+| `Square` | $z^2$ | `() → ()` | Closed form for `(Square, Normal) →` non-central χ². |
+| `LogSquare` | $2\log\lvert z\rvert$ | `() → ()` | MC fallback. |
+| `GaussianLogLik(obs, cov)` | $\log\mathcal{N}(\mathrm{obs} \mid z, \mathrm{cov})$ | `(d,) → ()` | Used by forward-model forms. |
+| `LogProb(dist)` | $\log p_\mathrm{dist}(z)$ | `dist.event_shape → ()` | Used as `shift` for prior addition. |
+
+Note that `Constant`, `LogProb`, and `GaussianLogLik` close over their
+parameters at construction; the `__call__` is single-argument.
+
+### 3.3 ProbPipe alignment
+
+The `Map` ABC, the shape contract, and the per-`Map` pushforward
+dispatch all match what ProbPipe is converging on. Bijectors will
+land in ProbPipe as a `Map` subclass that adds `inverse` and
+`log_det_jacobian`; sabi's `Map` ABC is the strict superclass.
+
+When ProbPipe's `Map` lands, sabi's becomes a re-export and our concrete
+maps probably migrate to ProbPipe entirely. The `pushforward(Map,
+Distribution)` op also moves up. The migration is rename-level, not
+refactor-level, and is the explicit motivation for the design choices in
+this section.
+
+## 4. The `DensityForm` abstraction
 
 ```python
-def pushforward(map: Map, dist: Distribution) -> Distribution:
-    """Multiple-dispatch: closed form for known (Map, Distribution) pairs; MC fallback."""
+@dataclass(frozen=True)
+class DensityForm:
+    link:  Map                                          # y → log-density-residual
+    shift: Map = Constant(0.0)                          # x → additive shift, default zero
+    constraint: Constraint = NoConstraint               # constraint on y values
+
+    def __call__(self, x: Array, y: Array) -> Array:
+        """Deterministic evaluation: log-density at (x, y)."""
+        return self.link(y) + self.shift(x)
+
+    def pushforward(self, x: Array, y: Distribution) -> Distribution:
+        """Push the emulator's predictive `y` at point(s) `x` to log-density."""
+        per_x_map = Affine(slope=1.0, intercept=self.shift(x)) @ self.link
+        return pushforward(per_x_map, y)
 ```
 
-Closed-form registrations land per (Map type, Distribution type):
+The form decomposes log-density as $\Phi(x, y) = \mathrm{link}(y) +
+\mathrm{shift}(x)$ — a single-variable `link` (in $y$) plus a deterministic
+additive shift (in $x$). All x-dependence enters through the shift.
 
-| Map | Distribution | Pushforward result |
-|-----|-------------|--------------------|
-| `Identity` | any | the same distribution |
-| `Affine(a, b)` | `Normal(loc, scale)` | `Normal(a·loc + b, |a|·scale)` |
-| `Affine(a, b)` | `MultivariateNormal(loc, scale_tril)` | `MultivariateNormal(a·loc + b, |a|·scale_tril)` |
-| `Square` | `Normal(loc, scale)` | scaled non-central chi-squared, df=1 |
-| `Log` | `Normal(loc, scale)` | log-normal |
-| `Softplus`, `LogSoftplus` | `Normal` | no closed form — falls through to MC |
-| `Compose(f, g)` | any | `pushforward(f, pushforward(g, dist))` |
-| (any) | `SupportsSampling` | MC fallback via the existing `_batch_form` machinery |
+### 4.1 Specific forms
 
-The MC fallback is the existing `@workflow_function`-wrapped batched-form
-pattern, generalised: any callable wrapped with `@workflow_function` becomes
-a pushforward when handed a `Distribution` in a non-Distribution-typed slot.
-Sabi already does this for `_batch_form`; the `Map` abstraction just gives
-it a name.
-
-### 5.3 What this gets us
-
-The composition for "marginal random log-density at $X$" decomposes
-explicitly:
+The current `LogDensityForm` subclasses become construction idioms:
 
 ```python
-emulator_predictive = emulator(X)                           # Distribution[Array]
-log_lik_predictive  = pushforward(form.link.log_link_map(),
-                                  emulator_predictive)      # Distribution[Array]
-log_density_predictive = log_lik_predictive + log_prior(X)  # Distribution[Array] + Array
+# Today's Identity (log-density emulator):
+DensityForm(link=Identity())
+
+# Today's LogLikPlusPrior (log-likelihood + prior, exp link):
+DensityForm(link=Identity(), shift=LogProb(prior))
+
+# Today's ForwardModel with Gaussian likelihood:
+DensityForm(link=GaussianLogLik(obs, cov), shift=LogProb(prior))
+
+# New: log-likelihood + prior, softplus link (issue #55's motivation):
+DensityForm(link=LogSoftplus(), shift=LogProb(prior))
+
+# New: log-likelihood + prior, square link:
+DensityForm(link=LogSquare(), shift=LogProb(prior), constraint=NonNegative())
 ```
 
-Each line is a separate, named operation. Acquisitions that want to query
-intermediate layers (next subsection) get them by composing different maps.
+No subclasses; the variation is entirely in the `Map`s. Convenience
+constructors (e.g. `log_lik_with_prior(prior, link=Identity())`) can be
+added if they aid discoverability, but they're sugar.
+
+### 4.2 What the emulator emits, in each case
+
+It is worth being explicit about this, since the answer changes with
+`link` and was the source of confusion in earlier drafts of this doc:
+
+| Form | What the emulator's $y$ represents |
+|------|-------------------------------------|
+| `link=Identity()`, `shift=Constant(0)` | log-density (full, prior absorbed). |
+| `link=Identity()`, `shift=LogProb(prior)` | log-likelihood. |
+| `link=LogSoftplus()`, `shift=LogProb(prior)` | $\mathrm{softplus}^{-1}(\mathrm{lik})$ — neither log nor density. The whole point of softplus is that this quantity has a more compact range than $\log\mathrm{lik}$ in the high-density region. |
+| `link=LogSquare()`, `shift=LogProb(prior)` | $\sqrt{\mathrm{lik}}$ (with sign). |
+| `link=GaussianLogLik(obs, C)`, `shift=LogProb(prior)` | A forward-model output (e.g. simulated observations). The likelihood is computed from $y$ via the Gaussian density. |
+
+`link=Identity()` with a `LogProb` shift is the common case: log-likelihood
+emulation, exp link, prior added. Choosing a non-identity `link` is opting
+into a different emulated quantity, deliberately.
+
+### 4.3 Constraints
+
+`Constraint` on $y$ is mostly metadata. Concrete constraints:
+
+- `NoConstraint` — default; `link` accepts any real $y$.
+- `NonNegative` — used by `Square`/`LogSquare` to pin sign convention.
+- `Positive` — for any link whose `log_link` has a singularity at zero.
+
+Acquisitions and pushforward primitives can read the constraint to
+validate inputs or pin sign conventions; the `DensityForm` itself does
+not enforce it (no runtime checks on $y$).
+
+## 5. Pushforward dispatch
+
+`pushforward(map, dist) → dist` is multiple-dispatch on `(type(map),
+type(dist))`. Closed-form registrations land per pair; an MC fallback
+covers everything else.
+
+### 5.1 Dispatch table
+
+For the typical sabi cases:
+
+| Map | `Normal(batch_shape=(n,))` | `MVN(event_shape=(n,))` |
+|-----|---------------------------|--------------------------|
+| `Identity` | unchanged | unchanged |
+| `Constant(c)` | `Dirac(c)` | `Dirac(c)` |
+| `Affine(slope, intercept)` | closed: `Normal(slope·loc + intercept, |slope|·scale)` | closed: `MVN(slope·loc + intercept, |slope|·scale_tril)` |
+| `Compose(f, g)` | `pushforward(f, pushforward(g, dist))` | same, via recursion |
+| `Exp` | closed: `LogNormal(loc, scale)` | MC |
+| `Log` | (only registered for `LogNormal`) | MC |
+| `Square` | non-central χ² (closed) | MC (no clean joint closed form) |
+| `Softplus`, `LogSoftplus`, `LogSquare`, `GaussianLogLik`, ... | MC | MC |
+
+### 5.2 Closed-form Gaussian-affine path
+
+The common case in sabi today is `link=Identity()` with
+`shift=LogProb(prior)`. The form's pushforward composes
+`Affine(slope=1, intercept=shift(x)) @ Identity = Affine(slope=1, intercept=shift(x))`.
+Pushing a `Normal` or `MVN` through this `Affine` shifts `loc` by
+`shift(x)` and leaves `scale` / `scale_tril` unchanged — equivalent to
+today's `_shift_gaussian_loc`, but as a generic Affine pushforward
+rather than form-specific code.
+
+### 5.3 MC fallback for nonlinear and joint cases
+
+For nonlinear element-wise Maps (e.g. `LogSoftplus`) or any
+`(Map, MultivariateNormal)` pair without a closed-form entry, the
+fallback samples from the input distribution, applies the Map per
+sample, and returns a `NumericEmpiricalDistribution`. The joint
+correlation structure (when applicable) is carried in the sample
+correlations. This is the existing `@workflow_function(n_broadcast_samples=64)`
+machinery (`_batch_form` at
+[`src/sabi/surrogate/_pushforward.py:163`](../src/sabi/surrogate/_pushforward.py)),
+generalised from "form-specific MC" to "any Map".
+
+### 5.4 Worked example: joint MVN through a form with softplus link
+
+Setting: GP emulator at $n$ query points, joint mode (returns
+`MVN(loc=(n,), scale_tril=(n, n))`); form is
+`DensityForm(link=LogSoftplus(), shift=LogProb(prior))`.
+
+```python
+emulator_pred = emulator(X)                 # MVN(event_shape=(n,))
+log_density_pred = form.pushforward(X, emulator_pred)
+```
+
+Internally:
+
+1. `form.pushforward` constructs `per_x_map = Affine(slope=1, intercept=shift(X)) @ LogSoftplus()`.
+   `shift(X)` has shape `(n,)`; `Affine.intercept` has shape `(n,)`.
+2. `pushforward(per_x_map, emulator_pred)` recurses through `Compose`:
+   first `pushforward(LogSoftplus(), MVN)` — no closed form, MC fallback
+   produces samples of shape `(S, n)`.
+3. Then `pushforward(Affine(slope=1, intercept=(n,)), empirical_dist)` —
+   shifts each sample's $i$-th component by `intercept[i]`. Closed form on
+   `NumericEmpiricalDistribution` (just elementwise add).
+4. Result: `NumericEmpiricalDistribution` of joint log-density samples,
+   shape `(S, n)`, with joint structure preserved through the Affine
+   shift.
+
+For the same form under joint MVN with `link=Identity()` (the common
+case), the entire path is closed form: step 2 collapses to identity, step
+3 is `pushforward(Affine, MVN)` → `MVN`, no MC needed.
+
+### 5.5 Point-set agnostic
+
+The form's `pushforward(x, y)` doesn't care about the choice of $X$ — it
+operates on whatever `Distribution` the emulator produces. Per-point
+marginal mode (`Normal` with `batch_shape=(n,)`), joint mode (`MVN` with
+`event_shape=(n,)`), heteroskedastic Gaussian, mixture, Student-$t$:
+all handled as long as the dispatch table has entries for the relevant
+`(Map, Distribution)` pair, otherwise MC.
 
 ## 6. Acquisition customisation axes
 
@@ -357,34 +345,42 @@ acquisition's surrogate is built:
 - `NEXT` — next round's intermediate (one-step look-ahead, SMC-flavour).
 - `TERMINAL` — final intermediate (always optimise toward the final target).
 
-This is unchanged by the link / bridging refactor — it sits at the
-algorithm level and is orthogonal to which layer is queried.
+This is unchanged by the form refactor — it sits at the algorithm level
+and is orthogonal to which layer is queried.
 
-### 6.2 Axis 2 — which predictive layer to target
+### 6.2 Axis 2: which predictive layer to target
 
 New axis, surfaced by the `Map`-dispatch design. A `SurrogateDistribution`
-(post-rename) exposes layered predictives:
+exposes layered predictives by composing different Maps on top of the
+emulator predictive:
 
 ```python
 class SurrogateDistribution:
-    def emulator_predictive_at(self, X) -> Distribution: ...     # raw emulator
-    def pre_link_predictive_at(self, X) -> Distribution: ...     # = emulator (alias for clarity)
-    def log_density_predictive_at(self, X) -> Distribution: ...  # current pushforward_marginal
-    def density_predictive_at(self, X) -> Distribution: ...      # = pushforward(link.link_map, emulator)
+    def emulator_predictive_at(self, x) -> Distribution:
+        """Raw emulator predictive (the y distribution itself)."""
+        return self._emulator(x)
+
+    def log_density_predictive_at(self, x) -> Distribution:
+        """Pushed through the form: log-density distribution at x."""
+        return self._form.pushforward(x, self._emulator(x))
+
+    def density_predictive_at(self, x) -> Distribution:
+        """Pushed through the form, then exp'd: density distribution at x."""
+        return pushforward(Exp(), self.log_density_predictive_at(x))
 ```
 
-(Aliasing `emulator_predictive_at` and `pre_link_predictive_at` makes both
-mental models accessible; the values are the same `Distribution`.)
+Each layer is a separate `Distribution`, accessed via a different `Map`
+composition. Acquisitions pick the layer they want.
 
-Acquisitions that vary on this axis carry it as a parameter:
+### 6.3 Acquisition example
 
 ```python
 @dataclass
 class MaxVariance(Acquisition):
-    target_intermediate: AcquisitionTarget = AcquisitionTarget.CURRENT  # axis 1
-    target_layer: PredictiveLayer = PredictiveLayer.LOG_DENSITY         # axis 2
+    target_intermediate: AcquisitionTarget = AcquisitionTarget.CURRENT
+    target_layer: PredictiveLayer = PredictiveLayer.LOG_DENSITY
 
-    def acquire(self, sp: SurrogateDistribution, X_candidate: Array) -> Array:
+    def acquire(self, sp: SurrogateDistribution, X_candidate) -> Array:
         match self.target_layer:
             case PredictiveLayer.EMULATOR:    pred = sp.emulator_predictive_at(X_candidate)
             case PredictiveLayer.LOG_DENSITY: pred = sp.log_density_predictive_at(X_candidate)
@@ -392,68 +388,62 @@ class MaxVariance(Acquisition):
         return variance(pred)
 ```
 
-Acquisitions that *don't* vary along axis 2 (e.g. log-EI, where the
-log-density layer is fixed by definition) simply don't take the parameter.
-
-### 6.3 Naming
+`PredictiveLayer` is a small enum:
 
 ```python
 class PredictiveLayer(Enum):
-    EMULATOR     = "emulator"      # raw emulator predictive
-    LOG_DENSITY  = "log_density"   # post-form, in log space
-    DENSITY      = "density"       # post-link, in density space
+    EMULATOR     = "emulator"
+    LOG_DENSITY  = "log_density"
+    DENSITY      = "density"
 ```
 
+Acquisitions that don't vary along axis 2 (e.g. log-EI, where the
+log-density layer is fixed by definition) simply omit the parameter.
+
 The two-axis structure should be documented prominently in
-`docs/acquisitions.md` (does not yet exist; would land alongside this work),
-and demonstrated end-to-end in the tutorial-notebook (see
-[§9](#9-phasing-and-follow-up-issues)).
+`docs/acquisitions.md` (does not yet exist; would land alongside this
+work) and demonstrated end-to-end in the bridging tutorial notebook
+(see [§9](#9-phasing-and-follow-up-issues)).
 
 ## 7. ProbPipe boundary — log-density at the MCMC seam
 
 Today, sabi exposes `TargetDistribution._unnormalized_log_prob(x) →
-log-density` to ProbPipe's `SupportsUnnormalizedLogProb` protocol. This is
-the only point where MCMC sees the form's output.
+log-density` to ProbPipe's `SupportsUnnormalizedLogProb` protocol. This
+is unchanged by the refactor: the form composes
+`link.log_link(y) + shift(x)` and returns the result. ProbPipe MCMC sees
+a log-density just like it does today.
 
-Under the link abstraction, the boundary is unchanged: `_unnormalized_log_prob`
-returns log-density. Inside, the form composes
-`link.log_link(y) + log_prob(prior, x)` and returns the result. ProbPipe MCMC
-sees a log-density just like it does today.
+For `Map`s whose `log_link` is numerically singular at certain inputs
+(e.g. `LogSquare` at $z = 0$), the `Map` author handles stability —
+not the boundary. The constraint metadata on `DensityForm` can express
+"$y$ should be non-negative" / "$y$ should be away from zero" so
+acquisitions can avoid problematic regions.
 
-For some links (e.g. `square` near $g \approx 0$), $\log\ell(g) = 2\log|g|$ is
-numerically singular. The form must implement `log_link` carefully — but
-this is the link author's responsibility, not the boundary's.
-
-A second protocol (`SupportsUnnormalizedDensity` returning density-scale)
-could be added later if and when ProbPipe lands one. Sabi does not need it
-to ship link functions.
+A second protocol returning density-scale (`SupportsUnnormalizedDensity`)
+could be added later if and when ProbPipe lands one; sabi does not need
+it to ship the form refactor.
 
 ## 8. Bridging
 
 (Renamed from "tempering". The mathematical concept is *bridging* — a
-parameterised path between an initial and a target distribution; tempering
-is one specific bridge family.)
-
-This section is intentionally long. Bridging is where the link choice
-interacts most subtly with existing machinery, and your second set of
-requirements asks for a clean abstraction that supports multiple bridge
-families and surfaces incompatible combinations as explicit errors.
+parameterised path between an initial and a target distribution;
+likelihood tempering is one specific bridge family.)
 
 ### 8.1 What's wrong with the current naming
 
 The current `TemperingScheme` is two abstractions in one:
 
 1. The mathematical *family of intermediate distributions* — defined by
-   $(\pi_0, \pi_\text{target}, \beta)$ for likelihood tempering, but the
-   concept generalises to other parametrisations.
+   $(\pi_0, \pi_\mathrm{target}, \beta)$ for likelihood tempering, but the
+   concept generalises to other parametrisations (mixture, data, ...).
 2. The algorithmic *strategy for realising the intermediate at each round* —
    either by rebuilding the form (`ViaForm`) or by rescaling the emulator
    target (`ViaTarget`).
 
 Conflating them means new bridge families inherit a `ViaForm`/`ViaTarget`
 distinction whether or not it makes sense for them, and link-compatibility
-dispatch (where some strategies only work under exp link) has nowhere clean
-to live.
+dispatch has nowhere clean to live. Renaming and reshaping in the same
+pass.
 
 ### 8.2 The new shape
 
@@ -468,237 +458,246 @@ class BridgingScheme(ABC):
     def is_invariant_form(self, state_a, state_b) -> bool: ...
 ```
 
-A `BridgingScheme` is defined purely in terms of (initial, target, state).
-Subclasses encode different bridge families *and* implementation strategies
-together, but with consistent naming that surfaces both axes:
+Subclasses encode bridge families plus implementation strategies:
 
 ```python
 class LikelihoodBridgeViaForm(BridgingScheme):
-    """Likelihood bridge: π_β = π₀ · L^β. β factor enters via the form."""
-    # Works under any link. Form-axis tempering.
+    """π_β = π_init · (π_target / π_init)^β. β factor enters via the form."""
 
 class LikelihoodBridgeViaTargetRescale(BridgingScheme):
-    """Likelihood bridge: π_β = π₀ · L^β. β factor enters via Y_train rescaling."""
-    # Works ONLY under ExpLink. Target-axis tempering.
-    # Raises at intermediate_target() time if the base form's link is not ExpLink.
+    """Same intermediate density family. β factor enters via Y_train rescaling.
+    Restricted to forms with link = Identity (the current ExpLink case)."""
+
+class GeometricBridge(BridgingScheme):
+    """π_β = π_init^(1-β) · π_target^β. For forms with shift = Constant(0)."""
 ```
 
-(The `Tempering` → `Bridging` rename is a search-and-replace across
-`src/sabi/tempering/` → `src/sabi/bridging/`, plus updating
-[`docs/tempering.md`](tempering.md) → `docs/bridging.md` with parallel
-content. Material churn but mechanical.)
+(The `sabi.tempering` → `sabi.bridging` rename is a search-and-replace
+across `src/sabi/tempering/` → `src/sabi/bridging/` plus updating
+[`docs/tempering.md`](tempering.md) → `docs/bridging.md`. Material churn
+but mechanical.)
 
-### 8.3 Why the via-target-rescale strategy needs ExpLink
+### 8.3 `LikelihoodBridgeViaForm`: link-agnostic bridging via Map composition
 
-The mathematical family of likelihood bridges is
+```python
+class LikelihoodBridgeViaForm(BridgingScheme):
+    initial: TargetDistribution
 
-$$\pi_\beta(x) \;\propto\; \pi_0(x) \cdot L(x)^\beta.$$
+    def intermediate_form(self, base: DensityForm, beta: float) -> DensityForm:
+        # The base form represents log_target = base.link(y) + base.shift(x),
+        # with shift typically = LogProb(prior). Tempering raises the likelihood
+        # part to β: π_init · (π_target / π_init)^β = link(y)^β · π_init(x).
+        # In log-space: β · base.link(y) + base.shift(x).
+        return DensityForm(
+            link=Affine(slope=beta, intercept=0.0) @ base.link,   # scale link by β
+            shift=base.shift,                                     # unchanged (= log p_init)
+            constraint=base.constraint,
+        )
+```
 
-The existing two strategies are equivalent under exp link because of the
-identity $\log L^\beta = \beta \log L$ — scaling the *log-likelihood* by
-$\beta$ is the same as raising the *likelihood* to power $\beta$.
+Note that the β-scaling is just a `Map` composition — nothing about it
+depends on `base.link`. This works under any link, including the new
+`LogSoftplus` and `LogSquare` cases. The current
+`_LogLikPlusPriorTempered` and `_ForwardModelTempered` collapse into
+this single rule.
 
-Under non-exp links, the emulator's output $g$ is no longer log-likelihood.
-For `SquareLink` ($g = \sqrt{L}$), raising likelihood to $\beta$ requires
-$g \mapsto g^\beta$, *not* $g \mapsto \beta g$. For `SoftplusLink`, there
-is no closed-form rescaling at all.
+### 8.4 `GeometricBridge` — for forms with shift = Constant(0)
 
-So:
+The current `_IdentityTempered` has `Identity` base form (no prior in the
+form) and produces $(1-\beta) \log\pi_0(x) + \beta \cdot y$. This is the
+geometric bridge:
 
-- **`LikelihoodBridgeViaForm` works under any link.** The form's
-  `_call_single` is rebuilt per state to compute
-  $\beta \cdot \log\ell(g(x)) + \log\pi_0(x)$. This is link-aware *only*
-  in that it uses the link's `log_link` method, which already exists. The
-  $\beta$ factor multiplies the log-likelihood (not the emulator output);
-  this is well-defined for every link.
-- **`LikelihoodBridgeViaTargetRescale` only works under `ExpLink`.** The
-  rescaling $Y_\text{train} = \beta \cdot Y_\text{raw}$ is mathematically
-  equivalent to via-form *only* when $g$ is log-likelihood, i.e. under
-  exp link. Other links would need link-specific rescaling — which we could
-  add per-link later, but the obvious cases (square, softplus) don't have
-  cheap closed-form rescaling, so the via-target-rescale optimisation
-  is genuinely exp-link-specific.
+```python
+class GeometricBridge(BridgingScheme):
+    initial: TargetDistribution
 
-### 8.4 Error dispatch
+    def intermediate_form(self, base: DensityForm, beta: float) -> DensityForm:
+        # base.shift is typically Constant(0); base.link encodes the full
+        # target log-density. New form interpolates between log p_init and
+        # base via β.
+        return DensityForm(
+            link=Affine(slope=beta, intercept=0.0) @ base.link,
+            shift=Affine(slope=(1 - beta), intercept=0.0) @ LogProb(self.initial),
+            constraint=base.constraint,
+        )
+```
 
-Per your third requirement, incompatible combinations raise informative
-errors at construction or scheme-application time. Concretely:
+The two bridges share "scale link by β" and differ only in shift handling:
+`LikelihoodBridgeViaForm` keeps the existing shift (because that shift
+*is* $\log\pi_\mathrm{init}$, not a separate term to bridge);
+`GeometricBridge` constructs a new shift $(1-\beta)\log\pi_\mathrm{init}$.
+
+### 8.5 `LikelihoodBridgeViaTargetRescale` — exp-link-only optimisation
+
+Today's `LikelihoodTemperingViaTarget` rescales `Y_train = β · Y_raw`.
+This is mathematically equivalent to via-form bridging *only* when the
+emulator's $y$ is log-likelihood, i.e. when `link == Identity()`. For
+non-`Identity` links, scaling $y$ by $\beta$ doesn't correspond to
+raising the link's output to power $\beta$.
 
 ```python
 class LikelihoodBridgeViaTargetRescale(BridgingScheme):
-    def intermediate(self, beta: float) -> IntermediateTarget:
-        link = self.target.density_form.link if hasattr(self.target.density_form, "link") else None
-        if not isinstance(link, ExpLink):
+    initial: TargetDistribution
+
+    def intermediate_target(self, base_form: DensityForm, beta: float):
+        if not isinstance(base_form.link, Identity):
             raise NotImplementedError(
-                f"LikelihoodBridgeViaTargetRescale requires the target form's link "
-                f"to be ExpLink, because Y_train = β·Y_raw is mathematically equivalent "
-                f"to via-form bridging only when g is log-likelihood. "
-                f"Got link={type(link).__name__}. "
-                f"Use LikelihoodBridgeViaForm (works under any link), or, if you want "
-                f"target-rescale optimisation under your link, file an issue describing "
-                f"the link-specific rescaling."
+                f"LikelihoodBridgeViaTargetRescale requires base_form.link "
+                f"to be Identity (so y is log-likelihood and scaling y by β "
+                f"is equivalent to scaling the link by β). "
+                f"Got link={type(base_form.link).__name__}. "
+                f"Use LikelihoodBridgeViaForm for non-Identity links."
             )
-        # ... existing target-rescale logic
+        # ... existing target-rescale logic.
 ```
 
-`ForwardModel` doesn't expose a `link` attribute (it has none), so the
-isinstance check above fails the way we want — `ForwardModel` is
-incompatible with `LikelihoodBridgeViaTargetRescale` and the error message
-should say so.
-
-### 8.5 Form-by-form bridge math
-
-Per-form details for `LikelihoodBridgeViaForm`, with explicit reference to
-the link:
-
-| Base form | Tempered density (any link) | Form output at state $\beta$ |
-|-----------|------------------------------|--------------------------------|
-| `Identity(link)` | $\pi_0(x)^{1-\beta} \cdot \ell(g(x))^\beta$ — geometric bridge | $(1-\beta) \log\pi_0(x) + \beta \log\ell(g(x))$ |
-| `LikelihoodWithPrior(link)` | $\pi_0(x) \cdot \ell(g(x))^\beta$ | $\log\pi_0(x) + \beta \log\ell(g(x))$ |
-| `ForwardModel(log_lik_from_outputs)` | $\pi_0(x) \cdot \exp(\beta \cdot \mathrm{log\_lik\_from\_outputs}(x, y))$ | $\log\pi_0(x) + \beta \cdot \mathrm{log\_lik\_from\_outputs}(x, y)$ |
-
-The `Identity` case is the geometric bridge, identical to today's
-`_IdentityTempered`. The `LikelihoodWithPrior` case generalises today's
-`_LogLikPlusPriorTempered` to any link by routing through `link.log_link`
-instead of treating $g$ as log-likelihood directly. The `ForwardModel`
-case is unchanged from today's `_ForwardModelTempered` (no link involved).
-
-The three classes collapse into a single `_LikelihoodBridgedForm` plus a
-small per-form-type dispatch (or a `match` statement on the base form's
-type — sabi already uses `isinstance` dispatch in the bridging module).
-The total LoC is smaller than the current three-class implementation.
+`ForwardModel` forms have `link=GaussianLogLik(obs, C)` — also not
+`Identity`, so the same error fires. No special `ForwardModel`-specific
+branch is needed.
 
 ### 8.6 Future bridge families
 
-`LikelihoodBridgeViaForm` is the first concrete bridge. Future families
-slot in alongside it without affecting the link abstraction:
+`LikelihoodBridgeViaForm` and `GeometricBridge` are the first two concrete
+bridges. Future families slot in as additional `BridgingScheme` subclasses
+without affecting `Map` or `DensityForm`:
 
-- `MixtureBridge`: $\pi_\beta = (1-\beta) \pi_0 + \beta \pi_\text{target}$.
-  Algebraically different (additive in densities, not multiplicative);
-  pushforward composes differently. Adds a new `BridgingScheme` subclass
-  with its own `intermediate` method.
+- `MixtureBridge`: $\pi_\beta = (1-\beta)\pi_0 + \beta\pi_\mathrm{target}$.
+  Algebraically additive in densities, not multiplicative; pushforward
+  composes differently. New `BridgingScheme` subclass.
 - `DataBridge`: $\pi_\beta(x) \propto \pi_0(x) \cdot \prod_{i \in S_\beta}
-  L_i(x)$ for some sequence of data subsets $S_\beta$. Adds a new
-  subclass; state PyTree is a subset index, not a scalar.
+  L_i(x)$ for a sequence of data subsets. State PyTree is a subset
+  index, not a scalar.
 
-Neither requires any change to `Link` or `DensityForm`. The bridge
-abstraction is link-agnostic in its mathematical content; link-compatibility
-checks live per-strategy.
+Neither requires changes to `Map` or `DensityForm`. The bridge abstraction
+is link-agnostic in its mathematical content; link-compatibility checks
+live per-strategy as in §8.5.
 
 ## 9. Phasing and follow-up issues
 
-This doc is the deliverable for **Phase 1** of the issue. Subsequent phases
-land in their own PRs / issues. The phasing acknowledges that this is now a
-materially larger refactor than the original issue scoped.
+This doc is the deliverable for **Phase 1** of the issue. Subsequent
+phases land in their own PRs / issues. The phasing acknowledges that
+this is now a materially larger refactor than the original issue scoped.
 
 1. **Phase 1 — design doc** (this PR). No code changes.
-2. **Phase 2 — `Link` + `Map` infrastructure** (separate issue/PR). Add
-   `Link` ABC and `ExpLink` concrete subclass; add `Map` ABC, concrete
-   maps (`Identity`, `Affine`, `Log`, etc.), `pushforward(Map,
+2. **Phase 2 — `Map` + `pushforward` infrastructure** (separate
+   issue/PR). Add the `Map` ABC; concrete maps (`Identity`, `Constant`,
+   `Affine`, `Compose`, `Exp`, `Log`, `Softplus`, `LogSoftplus`, `Square`,
+   `LogSquare`, `LogProb`, `GaussianLogLik`); the `pushforward(Map,
    Distribution)` multiple-dispatch op with closed-form registrations
-   and MC fallback. No form / surrogate / bridging changes yet — this
-   phase ships the primitives.
-3. **Phase 3 — `DensityForm` + form rename** (separate issue/PR).
-   `LogDensityForm` → `DensityForm`; `LogLikPlusPrior` →
-   `LikelihoodWithPrior`; add `link: Link` field to `Identity` and
-   `LikelihoodWithPrior`; rewrite `_call_single` bodies in terms of
-   `link.log_link`. `ForwardModel` unchanged. Behaviour-preserving for
-   all existing tests under `ExpLink`; benchmarks unchanged.
+   for the entries in [§5.1](#51-dispatch-table) and an MC fallback
+   that generalises today's `_batch_form`. No form / surrogate /
+   bridging changes yet — this phase ships the primitives.
+3. **Phase 3 — `DensityForm` rewrite** (separate issue/PR). Collapse
+   `LogDensityForm` family into single `DensityForm(link, shift,
+   constraint)` per [§4](#4-the-densityform-abstraction). Update
+   construction sites in problems / tests to use the new constructor
+   shape. The closed-form pushforward for `(Affine, Normal | MVN)`
+   makes `_shift_gaussian_loc` redundant; remove. `pushforward_marginal`
+   becomes a thin wrapper around `form.pushforward(x, y)`.
 4. **Phase 4 — surrogate layered predictive access** (separate
    issue/PR). Add `SurrogateDistribution.{emulator,log_density,density}_predictive_at`
-   methods, all built on the Phase 2 pushforward op. Audit current
-   acquisitions for layer-access opportunities; introduce
-   `PredictiveLayer` enum and add `target_layer` parameter to acquisitions
-   that benefit (likely just `MaxVariance` for now).
+   per [§6.2](#62-axis-2-which-predictive-layer-to-target). Audit
+   current acquisitions for layer-access opportunities; introduce
+   `PredictiveLayer` enum and add `target_layer` parameter to
+   acquisitions that benefit (likely just `MaxVariance` for now).
 5. **Phase 5 — bridging rename + collapse** (separate issue/PR).
    `sabi.tempering` → `sabi.bridging`; `TemperingScheme` →
-   `BridgingScheme`; collapse the three `_*Tempered` form classes into
-   one `_LikelihoodBridgedForm` with per-base-form dispatch;
-   `LikelihoodTemperingViaForm` → `LikelihoodBridgeViaForm`;
-   `LikelihoodTemperingViaTarget` → `LikelihoodBridgeViaTargetRescale`,
-   raising on non-exp link.
-6. **Phase 6 — `SoftplusLink`** (separate issue/PR). Concrete link with
-   numerically-stable `log_link` and `inv_link`; `LogSoftplus` map and
-   Gauss–Hermite or MC pushforward primitive; end-to-end test on a
-   synthetic 2D posterior comparing GP fit quality and posterior recovery
-   against `ExpLink`.
-7. **Phase 7 — `SquareLink`** (separate issue/PR). Concrete link with
-   sign-convention pinning; `LogSquare` and `Square` maps; non-central
-   chi-squared closed-form pushforward; benchmark validation.
-8. **Phase 8 — bridging tutorial notebook** (separate issue/PR). A new
-   notebook in `docs/` (or `docs/tutorials/`) that explores the bridging
-   abstraction across several worked cases: untempered loop,
-   `LikelihoodBridgeViaForm` under `ExpLink`, `LikelihoodBridgeViaForm`
-   under `SoftplusLink`, `LikelihoodBridgeViaTargetRescale` under
-   `ExpLink`, the failure mode of `LikelihoodBridgeViaTargetRescale +
-   SoftplusLink` (showing the error). Covers your documentation
-   requirement; the notebook is the primary artefact for
-   "bridging × emulators × acquisitions interaction" understanding.
-9. **Phase 9 — link-aware acquisition audit** (separate issue/PR). Audit
-   acquisitions for tail-sensitivity introduced by exp link; introduce
-   link-aware variants of EI / VBMC-style acquisitions where the
-   closed-form depends on the link choice.
+   `BridgingScheme`; per-form-type `_*Tempered` classes collapse into
+   `LikelihoodBridgeViaForm.intermediate_form` returning a single
+   `DensityForm` (per [§8.3](#83-likelihoodbridgeviaform-link-agnostic-bridging-via-map-composition));
+   `_IdentityTempered` becomes `GeometricBridge`;
+   `LikelihoodTemperingViaTarget` becomes
+   `LikelihoodBridgeViaTargetRescale` raising on non-`Identity` link.
+6. **Phase 6 — softplus link end-to-end** (separate issue/PR). Verify
+   `Softplus` and `LogSoftplus` numerical stability in `log_link`;
+   register pushforward dispatch entries (closed-form where applicable,
+   MC fallback elsewhere); end-to-end test on a synthetic 2D posterior
+   comparing GP fit quality and posterior recovery against the
+   `Identity` link baseline.
+7. **Phase 7 — square link end-to-end** (separate issue/PR). Verify
+   `Square` and `LogSquare` numerical stability; pin sign convention
+   via `NonNegative` constraint and any required output transform;
+   register non-central χ² closed-form pushforward; benchmark
+   validation.
+8. **Phase 8 — bridging tutorial notebook** (separate issue/PR). New
+   notebook `docs/tutorials/bridging.ipynb` (or similar) walking through
+   several worked cases: untempered, `LikelihoodBridgeViaForm` under
+   `Identity` link, `LikelihoodBridgeViaForm` under `LogSoftplus` link,
+   `GeometricBridge`, `LikelihoodBridgeViaTargetRescale` (and its
+   failure mode under non-`Identity` link with the informative error).
+   Covers the documentation requirement; the notebook is the primary
+   artefact for "bridging × emulators × acquisitions interaction"
+   understanding.
+9. **Phase 9 — link-aware acquisition audit** (separate issue/PR).
+   Audit acquisitions for tail-sensitivity introduced by exp link;
+   introduce link-aware variants of EI / VBMC-style acquisitions where
+   the closed-form depends on the link choice.
 
 Phases 2 and 3 are tightly coupled but worth separating: Phase 2's
-`Link` + `Map` infrastructure can land and be tested in isolation
-(unit-test the maps, the pushforward dispatch); Phase 3 wires them into
-the existing form hierarchy without surprises. Phases 6 and 7 can land
-in either order. Phase 8 is the documentation artefact; consider
-landing pieces of it incrementally as Phases 6/7 enable each scenario.
+infrastructure can land and be unit-tested in isolation (test the maps,
+the pushforward dispatch); Phase 3 wires them into the existing form
+hierarchy. Phases 6 and 7 can land in either order. Phase 8 lands
+incrementally as 6/7 enable each scenario.
 
 ## 10. Open questions
 
-1. **Multimodal sign convention for square link.** How is $g$'s sign pinned
-   in the multimodal case? Most natural: assume $g \ge 0$ everywhere via a
-   prior or a transform, but this gives back the non-negativity constraint
-   we were trying to avoid. Defer to the square-link implementation PR
-   (Phase 7).
-2. **Per-`Problem` vs per-run link choice.** Is the link a property of the
-   `Problem` (the user picks it once) or a per-run config (the runner
-   sweeps it for ablation)? Default: `Problem` carries it (via the form's
-   `link` field), but the runner can override for ablation by constructing
-   a copy of the problem with a different form.
-3. **Inferred / learned links.** Out of scope; composes with #3 (input/output
-   transforms). Listed as a longer-term direction.
-4. **`ForwardModel` link variant.** Should there be a `ForwardModel` variant
-   that exposes a `Link`, where the user supplies $\mathrm{lik\_from\_outputs}
-   (x, y) \to \mathrm{pre\text{-}link\ likelihood}$ instead of
-   $\log L$? Current proposal: no — the user can do this inside their
-   existing `log_lik_from_outputs` callback. But if a use case emerges,
-   adding `ForwardModelWithLink` is additive.
-5. **`pre_link_predictive_at` vs `emulator_predictive_at` aliasing.** The
-   two names describe the same value (the emulator's predictive). Aliasing
-   is for clarity — does it instead introduce confusion? Could ship with
-   just `emulator_predictive_at` and let the docstring explain that it's
-   also "the pre-link distribution".
+1. **Multimodal sign convention for `Square` link.** How is $y$'s sign
+   pinned in the multimodal case? Most natural: assume $y \ge 0$
+   everywhere via a prior or an output transform, but this gives back
+   the non-negativity constraint we were trying to avoid. Defer to
+   Phase 7.
+2. **Per-`Problem` vs per-run link choice.** Is the `link` a property
+   of the `Problem` (the user picks it once) or a per-run config (the
+   runner sweeps it for ablation)? Default: `Problem` carries it (via
+   the form's `link` field), but the runner can override for ablation
+   by constructing a copy of the problem with a different form.
+3. **Heteroskedastic forward models.** Forms where the likelihood depends
+   on $x$ multiplicatively (e.g. $\log\mathcal{N}(\mathrm{obs} \mid f(x),
+   C(x))$ with $x$-dependent noise covariance) violate the
+   "additive x-shift only" constraint. The shape of `DensityForm` doesn't
+   support this directly. Users with this case can subclass `DensityForm`
+   and override `__call__` / `pushforward`; no abstraction in the base
+   needs to bend. Worth a paragraph in the user-facing docs, not a
+   feature in v1.
+4. **Default `link` and `shift` arguments.** Should `DensityForm()` with
+   no arguments give `link=Identity(), shift=Constant(0)` (a
+   log-density-emulator form)? It's the "simplest" default, but may
+   confuse users who expect to specify a prior. Lean toward requiring
+   explicit `link` (no default) but defaulting `shift=Constant(0)`.
+5. **Bijector unification.** When ProbPipe's bijectors land as a `Map`
+   subclass, can sabi's `Map` ABC be the same? Likely yes; revisit when
+   ProbPipe ships.
 
 ## 11. Composition with adjacent issues
 
 - **#3 — input/output transforms.** Output-side warps (e.g. an affine
-  standardisation of `Y_train`) sit *between* the emulator and the link in
-  the layer chain. The link is "what the emulator's pre-warp output means
-  as a density"; the output transform is "what the emulator's training
-  input is, given a pre-link target value." A learned warp composed with
-  an exp link can recover softplus-like behaviour, but the abstractions
-  are conceptually distinct — the link is a fixed mathematical
+  standardisation of `Y_train`) sit *between* the emulator and the form
+  in the layer chain. A learned warp composed with `link=Identity()`
+  can recover softplus-like behaviour, but the abstractions are
+  conceptually distinct — the form's link is a fixed mathematical
   relationship, the warp is a learned change of variables.
-- **#50 — noisy targets.** Both touch the pushforward dispatch. The noise
-  enters by perturbing the emulator's predictive at observed points; the
-  link is downstream of that. The closed-form pushforward registrations in
-  [§5.2](#52-the-pushforward-op) must compose with whatever noise model #50
-  lands. Designing the link abstraction first means the noise work has
-  fewer link-specific decisions to make.
+- **#50 — noisy targets.** Both touch the pushforward dispatch. The
+  noise enters by perturbing the emulator's predictive at observed
+  points; the form's `link` is downstream of that. The closed-form
+  pushforward registrations in [§5.1](#51-dispatch-table) must compose
+  with whatever noise model #50 lands. Designing the form abstraction
+  first means the noise work has fewer link-specific decisions to
+  make.
 - **#4 — `update_emulator` cheap-path dispatch.** The emulator-update
-  optimisation interacts with `LikelihoodBridgeViaTargetRescale`: when only
-  $Y_\text{train}$ is rescaled, a cheap update is possible. With
-  link-compatibility error dispatch (only ExpLink supports the rescale),
-  the cheap-update path remains a clean optimisation.
+  optimisation interacts with `LikelihoodBridgeViaTargetRescale`: when
+  only $Y_\mathrm{train}$ is rescaled, a cheap update is possible.
+  With link-compatibility error dispatch (only `Identity` link
+  supports the rescale), the cheap-update path remains a clean
+  optimisation.
 
 ## 12. Style references
 
 - [`docs/design.md`](design.md) — overall sabi architecture.
-- [`docs/tempering.md`](tempering.md) — current tempering design (will be
-  rewritten as `docs/bridging.md` in Phase 5; this doc and that one
+- [`docs/tempering.md`](tempering.md) — current tempering design (will
+  be rewritten as `docs/bridging.md` in Phase 5; this doc and that one
   should be kept in sync after Phase 5).
 - [`docs/probpipe_random_measure_proposal.md`](probpipe_random_measure_proposal.md)
   — proposal-style design doc that informed this one.
+- [`docs/notation.md`](notation.md) — shape conventions; the `Map`
+  shape contract in [§3.1](#31-shape-contract) follows the same
+  per-event / batch-broadcasting conventions.

--- a/docs/link_functions.md
+++ b/docs/link_functions.md
@@ -1,6 +1,6 @@
-# Form abstraction refactor — `DensityForm`, `Map`, and bridging
+# Form abstraction refactor — `DensityDecomposition`, `Map`, and bridging
 
-**Status:** draft v0.3 — pre-implementation
+**Status:** draft v0.4 — pre-implementation
 **Issue:** [#55](https://github.com/arob5/sabi/issues/55)
 **Last updated:** 2026-05-07
 
@@ -8,14 +8,12 @@
 >
 > 1. **Form unification.** Collapse today's `LogDensityForm` hierarchy
 >    (`Identity`, `LogLikPlusPrior`, `ForwardModel`) into a single
->    `DensityForm` parameterised by a `Map` (the link from emulator output
->    to log-density-residual) plus an additive `Map` shift (the
->    deterministic x-dependent term, typically a log-prior). Specific forms
->    — including alternative link functions like softplus and square —
->    become `Map` compositions, not subclasses.
+>    parametric host class with `(link: Map, shift: Map, constraint)`
+>    fields. Specific forms — including alternative link functions like
+>    softplus and square — become `Map` compositions, not subclasses.
 > 2. **Bridging rename and reshape.** `TemperingScheme` becomes
 >    `BridgingScheme`. Likelihood tempering is one bridge family among
->    several future ones; bridges operate on a `DensityForm` by composing
+>    several future ones; bridges operate on the host class by composing
 >    `Map`s on its `link` and `shift`.
 >
 > A `pushforward(Map, Distribution) → Distribution` multi-dispatch op
@@ -23,6 +21,16 @@
 > through forms. The `Map` abstraction is intentionally aligned with what
 > ProbPipe is converging on; sabi's local op becomes a re-export when
 > ProbPipe lands.
+>
+> **Coordination with [PR #63](https://github.com/arob5/sabi/pull/63).** The
+> host class is named `DensityDecomposition` and lives at top-level
+> `src/sabi/density_decomposition.py`, per the `TargetDistribution` /
+> `DensityDecomposition` split that PR #63 introduces. PR #63 carries the
+> rename and extends the class with `target_single` + `output_shape`
+> fields; this PR (#59) contributes the `(link, shift)` `Map` shape,
+> the `Map` ABC + concrete maps, the `pushforward(Map, Distribution)`
+> dispatch, and the bridging restructure. The two PRs land
+> sequentially — recommended order in [§9](#9-phasing-and-follow-up-issues).
 >
 > This is a **design-only** PR: no source code changes. Implementation is
 > split across follow-up issues (see [§9](#9-phasing-and-follow-up-issues)).
@@ -54,27 +62,31 @@ specific. Adding alternative link functions to `LogLikPlusPrior` (issue
 #55's original framing) means either patching the class with a `link`
 field or adding new sibling classes; both fight the underlying structure.
 
-The structural fix is to collapse the hierarchy. Define `DensityForm` as a
-thin combination of:
+The structural fix is to collapse the hierarchy. Define a single host
+class (`DensityDecomposition`, per [PR #63](https://github.com/arob5/sabi/pull/63))
+that combines:
 
 - a `Map` `link: y \mapsto z` (the emulator-output side; ranges from the
   identity to a Gaussian log-likelihood),
 - a `Map` `shift: x \mapsto z'` (the deterministic x-dependent additive
-  term, typically a log-prior),
-- a `Constraint` on $y$.
+  term, typically a log-prior closed in at construction),
+- a `Constraint` on $y$,
+- (per PR #63) `target_single` and `output_shape`, the description of
+  what the emulator approximates.
 
 Specific forms become specific `Map` choices. Alternative link functions
 are concrete `Map` subclasses (`Softplus`, `LogSoftplus`, `Square`, …)
 that slot in. Forward-model emulation is a `Map` choice
-(`GaussianLogLik`). Tempering is `Map` composition on a base form's
+(`GaussianLogLik`). Tempering is `Map` composition on the host's
 `link`. The downstream pushforward / estimator / acquisition machinery
 dispatches on `Map` types, not on form subclasses.
 
 The exponential link is no longer privileged — under this design, the
-default form for log-density emulation is `DensityForm(link=Identity())`;
-log-likelihood-plus-prior under exp link is `DensityForm(link=Identity(),
-shift=LogProb(prior))`; under softplus link, `DensityForm(link=LogSoftplus(),
-shift=LogProb(prior))`. The codepath is the same in all three cases.
+default form for log-density emulation has `link=Identity()`;
+log-likelihood-plus-prior under exp link has `link=Identity(),
+shift=LogProb(modeling_prior)`; under softplus link, `link=LogSoftplus(),
+shift=LogProb(modeling_prior)`. The codepath is the same in all three
+cases.
 
 ## 2. Current state map
 
@@ -82,7 +94,7 @@ The form hierarchy and its consumers:
 
 | Site | What it does |
 |------|--------------|
-| [`src/sabi/problems/forms.py`](../src/sabi/problems/forms.py) | `LogDensityForm` family — `Identity`, `LogLikPlusPrior`, `ForwardModel`. Three classes for one abstraction. |
+| [`src/sabi/problems/forms.py`](../src/sabi/problems/forms.py) | `LogDensityForm` family — `Identity`, `LogLikPlusPrior`, `ForwardModel`. Three classes for one abstraction. (Module moves to top-level `src/sabi/density_decomposition.py` per [PR #63](https://github.com/arob5/sabi/pull/63).) |
 | [`src/sabi/surrogate/_pushforward.py:79`](../src/sabi/surrogate/_pushforward.py) | `pushforward_marginal` dispatches on `(input_dist, form_subclass)` for closed-form Gaussian-affine, falls back to MC for everything else. |
 | [`src/sabi/surrogate/_pushforward.py:144`](../src/sabi/surrogate/_pushforward.py) | `_shift_gaussian_loc` — bespoke handling of "shift `loc` by per-point log-prior, leave `scale_tril` alone." Generalises to any `Affine` Map. |
 | [`src/sabi/surrogate/estimators.py:129`](../src/sabi/surrogate/estimators.py) | `_ExpectedTargetDistribution._unnormalized_log_prob` plug-in mean. The bias note at line 15 is a symptom of the existing exp-link composition. |
@@ -93,8 +105,9 @@ The form hierarchy and its consumers:
 Two things stand out:
 
 - The pushforward / tempering layers branch on form *subclass*. Adding a
-  new link function multiplies this branching. A single `DensityForm` with
-  composable `Map`s collapses the branching into per-Map dispatch.
+  new link function multiplies this branching. A single
+  `DensityDecomposition` with composable `Map`s collapses the branching
+  into per-Map dispatch.
 - `_shift_gaussian_loc` is a one-off Gaussian-affine pushforward primitive.
   Generalising to `pushforward(Affine, Normal | MVN)` makes it the first
   entry in a registry that handles arbitrary `Map`s.
@@ -173,18 +186,31 @@ Distribution)` op also moves up. The migration is rename-level, not
 refactor-level, and is the explicit motivation for the design choices in
 this section.
 
-## 4. The `DensityForm` abstraction
+## 4. The `DensityDecomposition` host class
+
+The host class is `DensityDecomposition`, defined fully in
+[PR #63](https://github.com/arob5/sabi/pull/63)'s
+`docs/density_decomposition.md`. It carries the `link` / `shift` / `constraint`
+fields contributed by this PR, plus `target_single` and `output_shape`
+contributed by PR #63 (the description of what the emulator approximates).
+The combined shape:
 
 ```python
 @dataclass(frozen=True)
-class DensityForm:
-    link:  Map                                          # y → log-density-residual
-    shift: Map = Constant(0.0)                          # x → additive shift, default zero
-    constraint: Constraint = NoConstraint               # constraint on y values
+class DensityDecomposition:
+    target_single: Callable[[Array], Array]   # x -> y    (PR #63)
+    output_shape: tuple[int, ...]              # shape of one y    (PR #63)
+    link:  Map                                  # y -> log-density-residual    (this PR)
+    shift: Map = Constant(0.0)                  # x -> additive shift    (this PR)
+    constraint: Constraint = NoConstraint       # constraint on y    (this PR)
 
     def __call__(self, x: Array, y: Array) -> Array:
         """Deterministic evaluation: log-density at (x, y)."""
         return self.link(y) + self.shift(x)
+
+    def density_at(self, x: Array) -> Array:
+        """Compose target_single with link/shift: log-density at x."""
+        return self(x, self.target_single(x))
 
     def pushforward(self, x: Array, y: Distribution) -> Distribution:
         """Push the emulator's predictive `y` at point(s) `x` to log-density."""
@@ -192,51 +218,64 @@ class DensityForm:
         return pushforward(per_x_map, y)
 ```
 
-The form decomposes log-density as $\Phi(x, y) = \mathrm{link}(y) +
-\mathrm{shift}(x)$ — a single-variable `link` (in $y$) plus a deterministic
-additive shift (in $x$). All x-dependence enters through the shift.
+The decomposition's log-density is $\Phi(x, y) = \mathrm{link}(y) +
+\mathrm{shift}(x)$ — a single-variable `link` (in $y$) plus a
+deterministic additive shift (in $x$). All x-dependence enters through
+the shift. The modeling prior, when present, closes into the `shift`
+`Map` at construction time (typically `shift = LogProb(modeling_prior)`)
+— it is not pulled from a `target.prior` field at call time. PR #63
+drops the `prior` field from `TargetDistribution` for exactly this
+reason.
 
-### 4.1 Specific forms
+### 4.1 Specific decompositions
 
-The current `LogDensityForm` subclasses become construction idioms:
+The current `LogDensityForm` subclasses become construction idioms.
+The ProbPipe-style examples below show the `link` / `shift` choices
+this PR introduces; PR #63's helper classmethods (`identity_from_target`,
+`likelihood_with_prior`, `forward_model`) wrap the common patterns and
+are the recommended user-facing entry points.
 
 ```python
 # Today's Identity (log-density emulator):
-DensityForm(link=Identity())
+DensityDecomposition(target_single=..., output_shape=(), link=Identity())
 
 # Today's LogLikPlusPrior (log-likelihood + prior, exp link):
-DensityForm(link=Identity(), shift=LogProb(prior))
+DensityDecomposition(target_single=..., output_shape=(),
+                     link=Identity(), shift=LogProb(modeling_prior))
 
 # Today's ForwardModel with Gaussian likelihood:
-DensityForm(link=GaussianLogLik(obs, cov), shift=LogProb(prior))
+DensityDecomposition(target_single=..., output_shape=(d,),
+                     link=GaussianLogLik(obs, cov), shift=LogProb(modeling_prior))
 
 # New: log-likelihood + prior, softplus link (issue #55's motivation):
-DensityForm(link=LogSoftplus(), shift=LogProb(prior))
+DensityDecomposition(target_single=..., output_shape=(),
+                     link=LogSoftplus(), shift=LogProb(modeling_prior))
 
 # New: log-likelihood + prior, square link:
-DensityForm(link=LogSquare(), shift=LogProb(prior), constraint=NonNegative())
+DensityDecomposition(target_single=..., output_shape=(),
+                     link=LogSquare(), shift=LogProb(modeling_prior),
+                     constraint=NonNegative())
 ```
 
-No subclasses; the variation is entirely in the `Map`s. Convenience
-constructors (e.g. `log_lik_with_prior(prior, link=Identity())`) can be
-added if they aid discoverability, but they're sugar.
+No subclasses; the variation is entirely in the `Map`s.
 
 ### 4.2 What the emulator emits, in each case
 
 It is worth being explicit about this, since the answer changes with
 `link` and was the source of confusion in earlier drafts of this doc:
 
-| Form | What the emulator's $y$ represents |
-|------|-------------------------------------|
-| `link=Identity()`, `shift=Constant(0)` | log-density (full, prior absorbed). |
-| `link=Identity()`, `shift=LogProb(prior)` | log-likelihood. |
-| `link=LogSoftplus()`, `shift=LogProb(prior)` | $\mathrm{softplus}^{-1}(\mathrm{lik})$ — neither log nor density. The whole point of softplus is that this quantity has a more compact range than $\log\mathrm{lik}$ in the high-density region. |
-| `link=LogSquare()`, `shift=LogProb(prior)` | $\sqrt{\mathrm{lik}}$ (with sign). |
-| `link=GaussianLogLik(obs, C)`, `shift=LogProb(prior)` | A forward-model output (e.g. simulated observations). The likelihood is computed from $y$ via the Gaussian density. |
+| Decomposition | What the emulator's $y$ represents |
+|---------------|-------------------------------------|
+| `link=Identity()`, `shift=Constant(0)` | log-density (full, modeling prior absorbed into `target_single`). |
+| `link=Identity()`, `shift=LogProb(modeling_prior)` | log-likelihood. |
+| `link=LogSoftplus()`, `shift=LogProb(modeling_prior)` | $\mathrm{softplus}^{-1}(\mathrm{lik})$ — neither log nor density. The whole point of softplus is that this quantity has a more compact range than $\log\mathrm{lik}$ in the high-density region. |
+| `link=LogSquare()`, `shift=LogProb(modeling_prior)` | $\sqrt{\mathrm{lik}}$ (with sign). |
+| `link=GaussianLogLik(obs, C)`, `shift=LogProb(modeling_prior)` | A forward-model output (e.g. simulated observations). The likelihood is computed from $y$ via the Gaussian density. |
 
-`link=Identity()` with a `LogProb` shift is the common case: log-likelihood
-emulation, exp link, prior added. Choosing a non-identity `link` is opting
-into a different emulated quantity, deliberately.
+`link=Identity()` with a `LogProb` shift is the common case:
+log-likelihood emulation, exp link, modeling prior added. Choosing a
+non-identity `link` is opting into a different emulated quantity,
+deliberately.
 
 ### 4.3 Constraints
 
@@ -247,8 +286,8 @@ into a different emulated quantity, deliberately.
 - `Positive` — for any link whose `log_link` has a singularity at zero.
 
 Acquisitions and pushforward primitives can read the constraint to
-validate inputs or pin sign conventions; the `DensityForm` itself does
-not enforce it (no runtime checks on $y$).
+validate inputs or pin sign conventions; the `DensityDecomposition`
+itself does not enforce it (no runtime checks on $y$).
 
 ## 5. Pushforward dispatch
 
@@ -274,12 +313,12 @@ For the typical sabi cases:
 ### 5.2 Closed-form Gaussian-affine path
 
 The common case in sabi today is `link=Identity()` with
-`shift=LogProb(prior)`. The form's pushforward composes
-`Affine(slope=1, intercept=shift(x)) @ Identity = Affine(slope=1, intercept=shift(x))`.
-Pushing a `Normal` or `MVN` through this `Affine` shifts `loc` by
-`shift(x)` and leaves `scale` / `scale_tril` unchanged — equivalent to
-today's `_shift_gaussian_loc`, but as a generic Affine pushforward
-rather than form-specific code.
+`shift=LogProb(modeling_prior)`. The decomposition's pushforward
+composes `Affine(slope=1, intercept=shift(x)) @ Identity =
+Affine(slope=1, intercept=shift(x))`. Pushing a `Normal` or `MVN`
+through this `Affine` shifts `loc` by `shift(x)` and leaves `scale` /
+`scale_tril` unchanged — equivalent to today's `_shift_gaussian_loc`,
+but as a generic Affine pushforward rather than form-specific code.
 
 ### 5.3 MC fallback for nonlinear and joint cases
 
@@ -293,20 +332,21 @@ machinery (`_batch_form` at
 [`src/sabi/surrogate/_pushforward.py:163`](../src/sabi/surrogate/_pushforward.py)),
 generalised from "form-specific MC" to "any Map".
 
-### 5.4 Worked example: joint MVN through a form with softplus link
+### 5.4 Worked example: joint MVN through a softplus-link decomposition
 
 Setting: GP emulator at $n$ query points, joint mode (returns
-`MVN(loc=(n,), scale_tril=(n, n))`); form is
-`DensityForm(link=LogSoftplus(), shift=LogProb(prior))`.
+`MVN(loc=(n,), scale_tril=(n, n))`); decomposition is
+`DensityDecomposition(target_single=..., output_shape=(),
+link=LogSoftplus(), shift=LogProb(modeling_prior))`.
 
 ```python
-emulator_pred = emulator(X)                 # MVN(event_shape=(n,))
-log_density_pred = form.pushforward(X, emulator_pred)
+emulator_pred = emulator(X)                                  # MVN(event_shape=(n,))
+log_density_pred = decomposition.pushforward(X, emulator_pred)
 ```
 
 Internally:
 
-1. `form.pushforward` constructs `per_x_map = Affine(slope=1, intercept=shift(X)) @ LogSoftplus()`.
+1. `decomposition.pushforward` constructs `per_x_map = Affine(slope=1, intercept=shift(X)) @ LogSoftplus()`.
    `shift(X)` has shape `(n,)`; `Affine.intercept` has shape `(n,)`.
 2. `pushforward(per_x_map, emulator_pred)` recurses through `Compose`:
    first `pushforward(LogSoftplus(), MVN)` — no closed form, MC fallback
@@ -318,18 +358,18 @@ Internally:
    shape `(S, n)`, with joint structure preserved through the Affine
    shift.
 
-For the same form under joint MVN with `link=Identity()` (the common
-case), the entire path is closed form: step 2 collapses to identity, step
-3 is `pushforward(Affine, MVN)` → `MVN`, no MC needed.
+For the same decomposition under joint MVN with `link=Identity()` (the
+common case), the entire path is closed form: step 2 collapses to
+identity, step 3 is `pushforward(Affine, MVN)` → `MVN`, no MC needed.
 
 ### 5.5 Point-set agnostic
 
-The form's `pushforward(x, y)` doesn't care about the choice of $X$ — it
-operates on whatever `Distribution` the emulator produces. Per-point
-marginal mode (`Normal` with `batch_shape=(n,)`), joint mode (`MVN` with
-`event_shape=(n,)`), heteroskedastic Gaussian, mixture, Student-$t$:
-all handled as long as the dispatch table has entries for the relevant
-`(Map, Distribution)` pair, otherwise MC.
+The decomposition's `pushforward(x, y)` doesn't care about the choice
+of $X$ — it operates on whatever `Distribution` the emulator produces.
+Per-point marginal mode (`Normal` with `batch_shape=(n,)`), joint mode
+(`MVN` with `event_shape=(n,)`), heteroskedastic Gaussian, mixture,
+Student-$t$: all handled as long as the dispatch table has entries for
+the relevant `(Map, Distribution)` pair, otherwise MC.
 
 ## 6. Acquisition customisation axes
 
@@ -416,20 +456,25 @@ work) and demonstrated end-to-end in the bridging tutorial notebook
 ## 7. ProbPipe boundary — log-density at the MCMC seam
 
 Today, sabi exposes `TargetDistribution._unnormalized_log_prob(x) →
-log-density` to ProbPipe's `SupportsUnnormalizedLogProb` protocol. This
-is unchanged by the refactor: the form composes
-`link.log_link(y) + shift(x)` and returns the result. ProbPipe MCMC sees
-a log-density just like it does today.
+log-density` to ProbPipe's `SupportsUnnormalizedLogProb` protocol.
+After [PR #63](https://github.com/arob5/sabi/pull/63),
+`TargetDistribution` may implement `_unnormalized_log_prob`
+analytically (for benchmarks) or raise `NotImplementedError` (for user
+inverse problems). The MCMC-relevant random log-density boundary moves
+to `EmulatedDistribution._random_unnormalized_log_prob`, which composes
+the decomposition: `decomposition.link(y) + decomposition.shift(x)`,
+pushed through the emulator predictive. ProbPipe MCMC sees the same
+shape it does today.
 
 For `Map`s whose `log_link` is numerically singular at certain inputs
 (e.g. `LogSquare` at $z = 0$), the `Map` author handles stability —
-not the boundary. The constraint metadata on `DensityForm` can express
-"$y$ should be non-negative" / "$y$ should be away from zero" so
-acquisitions can avoid problematic regions.
+not the boundary. The constraint metadata on `DensityDecomposition` can
+express "$y$ should be non-negative" / "$y$ should be away from zero"
+so acquisitions can avoid problematic regions.
 
 A second protocol returning density-scale (`SupportsUnnormalizedDensity`)
 could be added later if and when ProbPipe lands one; sabi does not need
-it to ship the form refactor.
+it to ship the refactor.
 
 ## 8. Bridging
 
@@ -452,6 +497,12 @@ Conflating them means new bridge families inherit a `ViaForm`/`ViaTarget`
 distinction whether or not it makes sense for them, and link-compatibility
 dispatch has nowhere clean to live. Renaming and reshaping in the same
 pass.
+
+(Note: under the post-#63 layout, the `DensityDecomposition` lives on
+`Algorithm`, not on `Problem` or `IntermediateTarget`. Bridges produce a
+new `DensityDecomposition` per state; the bridging scheme reads the base
+decomposition off the algorithm and composes `Map`s on its `link` /
+`shift`.)
 
 ### 8.2 The new shape
 
@@ -491,12 +542,16 @@ but mechanical.)
 class LikelihoodBridgeViaForm(BridgingScheme):
     initial: TargetDistribution
 
-    def intermediate_form(self, base: DensityForm, beta: float) -> DensityForm:
-        # The base form represents log_target = base.link(y) + base.shift(x),
-        # with shift typically = LogProb(prior). Tempering raises the likelihood
-        # part to β: π_init · (π_target / π_init)^β = link(y)^β · π_init(x).
+    def intermediate_decomposition(
+        self, base: DensityDecomposition, beta: float
+    ) -> DensityDecomposition:
+        # The base decomposition represents log_target = base.link(y) + base.shift(x),
+        # with shift typically = LogProb(modeling_prior). Tempering raises the
+        # likelihood part to β: π_init · (π_target / π_init)^β = link(y)^β · π_init(x).
         # In log-space: β · base.link(y) + base.shift(x).
-        return DensityForm(
+        return DensityDecomposition(
+            target_single=base.target_single,                     # unchanged
+            output_shape=base.output_shape,                       # unchanged
             link=Affine(slope=beta, intercept=0.0) @ base.link,   # scale link by β
             shift=base.shift,                                     # unchanged (= log p_init)
             constraint=base.constraint,
@@ -507,32 +562,38 @@ Note that the β-scaling is just a `Map` composition — nothing about it
 depends on `base.link`. This works under any link, including the new
 `LogSoftplus` and `LogSquare` cases. The current
 `_LogLikPlusPriorTempered` and `_ForwardModelTempered` collapse into
-this single rule.
+this single rule. `target_single` and `output_shape` are passed through
+unchanged: bridging modifies how the emulator's output composes into
+log-density, not what the emulator approximates.
 
-### 8.4 `GeometricBridge` — for forms with shift = Constant(0)
+### 8.4 `GeometricBridge` — for decompositions with shift = Constant(0)
 
-The current `_IdentityTempered` has `Identity` base form (no prior in the
-form) and produces $(1-\beta) \log\pi_0(x) + \beta \cdot y$. This is the
-geometric bridge:
+The current `_IdentityTempered` has `Identity` base form (no prior in
+the decomposition) and produces $(1-\beta) \log\pi_0(x) + \beta \cdot
+y$. This is the geometric bridge:
 
 ```python
 class GeometricBridge(BridgingScheme):
     initial: TargetDistribution
 
-    def intermediate_form(self, base: DensityForm, beta: float) -> DensityForm:
+    def intermediate_decomposition(
+        self, base: DensityDecomposition, beta: float
+    ) -> DensityDecomposition:
         # base.shift is typically Constant(0); base.link encodes the full
-        # target log-density. New form interpolates between log p_init and
-        # base via β.
-        return DensityForm(
+        # target log-density. New decomposition interpolates between log p_init
+        # and base via β.
+        return DensityDecomposition(
+            target_single=base.target_single,
+            output_shape=base.output_shape,
             link=Affine(slope=beta, intercept=0.0) @ base.link,
             shift=Affine(slope=(1 - beta), intercept=0.0) @ LogProb(self.initial),
             constraint=base.constraint,
         )
 ```
 
-The two bridges share "scale link by β" and differ only in shift handling:
-`LikelihoodBridgeViaForm` keeps the existing shift (because that shift
-*is* $\log\pi_\mathrm{init}$, not a separate term to bridge);
+The two bridges share "scale link by β" and differ only in shift
+handling: `LikelihoodBridgeViaForm` keeps the existing shift (because
+that shift *is* $\log\pi_\mathrm{init}$, not a separate term to bridge);
 `GeometricBridge` constructs a new shift $(1-\beta)\log\pi_\mathrm{init}$.
 
 ### 8.5 `LikelihoodBridgeViaTargetRescale` — exp-link-only optimisation
@@ -547,27 +608,27 @@ raising the link's output to power $\beta$.
 class LikelihoodBridgeViaTargetRescale(BridgingScheme):
     initial: TargetDistribution
 
-    def intermediate_target(self, base_form: DensityForm, beta: float):
-        if not isinstance(base_form.link, Identity):
+    def intermediate_target(self, base: DensityDecomposition, beta: float):
+        if not isinstance(base.link, Identity):
             raise NotImplementedError(
-                f"LikelihoodBridgeViaTargetRescale requires base_form.link "
+                f"LikelihoodBridgeViaTargetRescale requires base.link "
                 f"to be Identity (so y is log-likelihood and scaling y by β "
                 f"is equivalent to scaling the link by β). "
-                f"Got link={type(base_form.link).__name__}. "
+                f"Got link={type(base.link).__name__}. "
                 f"Use LikelihoodBridgeViaForm for non-Identity links."
             )
         # ... existing target-rescale logic.
 ```
 
-`ForwardModel` forms have `link=GaussianLogLik(obs, C)` — also not
-`Identity`, so the same error fires. No special `ForwardModel`-specific
+Forward-model decompositions (`link=GaussianLogLik(obs, C)`) are also
+not `Identity`, so the same error fires. No special forward-model
 branch is needed.
 
 ### 8.6 Future bridge families
 
 `LikelihoodBridgeViaForm` and `GeometricBridge` are the first two concrete
 bridges. Future families slot in as additional `BridgingScheme` subclasses
-without affecting `Map` or `DensityForm`:
+without affecting `Map` or `DensityDecomposition`:
 
 - `MixtureBridge`: $\pi_\beta = (1-\beta)\pi_0 + \beta\pi_\mathrm{target}$.
   Algebraically additive in densities, not multiplicative; pushforward
@@ -576,15 +637,18 @@ without affecting `Map` or `DensityForm`:
   L_i(x)$ for a sequence of data subsets. State PyTree is a subset
   index, not a scalar.
 
-Neither requires changes to `Map` or `DensityForm`. The bridge abstraction
-is link-agnostic in its mathematical content; link-compatibility checks
-live per-strategy as in §8.5.
+Neither requires changes to `Map` or `DensityDecomposition`. The bridge
+abstraction is link-agnostic in its mathematical content; link-compatibility
+checks live per-strategy as in §8.5.
 
 ## 9. Phasing and follow-up issues
 
 This doc is the deliverable for **Phase 1** of the issue. Subsequent
-phases land in their own PRs / issues. The phasing acknowledges that
-this is now a materially larger refactor than the original issue scoped.
+phases land in their own PRs / issues. The phasing is now coordinated
+with [PR #63](https://github.com/arob5/sabi/pull/63) — that PR's
+implementation lands between this PR's Phase 2 and Phase 3, performing
+the rename + extension of the host class. Phases 3+ in this PR proceed
+against the post-#63 codebase.
 
 1. **Phase 1 — design doc** (this PR). No code changes.
 2. **Phase 2 — `Map` + `pushforward` infrastructure** (separate
@@ -594,46 +658,60 @@ this is now a materially larger refactor than the original issue scoped.
    Distribution)` multiple-dispatch op with closed-form registrations
    for the entries in [§5.1](#51-dispatch-table) and an MC fallback
    that generalises today's `_batch_form`. No form / surrogate /
-   bridging changes yet — this phase ships the primitives.
-3. **Phase 3 — `DensityForm` rewrite** (separate issue/PR). Collapse
-   `LogDensityForm` family into single `DensityForm(link, shift,
-   constraint)` per [§4](#4-the-densityform-abstraction). Update
-   construction sites in problems / tests to use the new constructor
-   shape. The closed-form pushforward for `(Affine, Normal | MVN)`
-   makes `_shift_gaussian_loc` redundant; remove. `pushforward_marginal`
-   becomes a thin wrapper around `form.pushforward(x, y)`.
-4. **Phase 4 — acquisition layered access** (separate issue/PR).
+   bridging changes yet — this phase ships the primitives both this PR
+   and PR #63 depend on.
+3. **PR #63's implementation** (sibling PR, lands between this PR's
+   phases 2 and 3). Renames `LogDensityForm` family →
+   `DensityDecomposition` (single class with `target_single`,
+   `output_shape`, `link`, `shift`, `constraint`), moves it to
+   top-level `src/sabi/density_decomposition.py`, restructures
+   `TargetDistribution` to drop its `prior` / `target_single` /
+   `output_shape` / `log_density_form` fields, splits the prior roles
+   across `Algorithm` / per-optimizer fields, and removes
+   `sampling.py`. See PR #63's design doc for the full migration
+   footprint.
+4. **Phase 3 (this PR, post-#63) — concrete `Map` subclasses for
+   non-default links** (separate issue/PR, possibly merged with Phase
+   2). After PR #63 lands, the `DensityDecomposition` shape is in
+   place; this phase ensures the `Softplus` / `LogSoftplus` / `Square`
+   / `LogSquare` `Map` subclasses are wired in with their pushforward
+   dispatch entries. (Largely subsumed by Phase 2 if the `Map` infra
+   ships all concrete subclasses together. Kept as a placeholder
+   phase in case shipping happens incrementally.)
+5. **Phase 4 — acquisition layered access** (separate issue/PR).
    `EmulatedDistribution` already exposes `emulator` as a property and
    implements `_random_unnormalized_log_prob` (via the
-   `pushforward_marginal` path that becomes `form.pushforward` after
-   Phase 3). Phase 4's work is acquisition-side: introduce the
-   `PredictiveLayer` enum and add `target_layer` parameter to
-   acquisitions that benefit (likely just `MaxVariance` for now), with
-   the dispatch wired to `surr_dist.emulator(X)` /
+   `pushforward_marginal` path that becomes
+   `decomposition.pushforward` after PR #63). Phase 4's work is
+   acquisition-side: introduce the `PredictiveLayer` enum and add
+   `target_layer` parameter to acquisitions that benefit (likely just
+   `MaxVariance` for now), with the dispatch wired to
+   `surr_dist.emulator(X)` /
    `random_unnormalized_log_prob(surr_dist, X)` /
    `pushforward(Exp(), random_unnormalized_log_prob(surr_dist, X))`
    per [§6.2](#62-axis-2-which-predictive-layer-to-target). No new
    methods on `SurrogateDistribution`.
-5. **Phase 5 — bridging rename + collapse** (separate issue/PR).
+6. **Phase 5 — bridging rename + collapse** (separate issue/PR).
    `sabi.tempering` → `sabi.bridging`; `TemperingScheme` →
    `BridgingScheme`; per-form-type `_*Tempered` classes collapse into
-   `LikelihoodBridgeViaForm.intermediate_form` returning a single
-   `DensityForm` (per [§8.3](#83-likelihoodbridgeviaform-link-agnostic-bridging-via-map-composition));
+   `LikelihoodBridgeViaForm.intermediate_decomposition` returning a
+   single `DensityDecomposition` (per
+   [§8.3](#83-likelihoodbridgeviaform-link-agnostic-bridging-via-map-composition));
    `_IdentityTempered` becomes `GeometricBridge`;
    `LikelihoodTemperingViaTarget` becomes
    `LikelihoodBridgeViaTargetRescale` raising on non-`Identity` link.
-6. **Phase 6 — softplus link end-to-end** (separate issue/PR). Verify
+7. **Phase 6 — softplus link end-to-end** (separate issue/PR). Verify
    `Softplus` and `LogSoftplus` numerical stability in `log_link`;
    register pushforward dispatch entries (closed-form where applicable,
    MC fallback elsewhere); end-to-end test on a synthetic 2D posterior
    comparing GP fit quality and posterior recovery against the
    `Identity` link baseline.
-7. **Phase 7 — square link end-to-end** (separate issue/PR). Verify
+8. **Phase 7 — square link end-to-end** (separate issue/PR). Verify
    `Square` and `LogSquare` numerical stability; pin sign convention
    via `NonNegative` constraint and any required output transform;
    register non-central χ² closed-form pushforward; benchmark
    validation.
-8. **Phase 8 — bridging tutorial notebook** (separate issue/PR). New
+9. **Phase 8 — bridging tutorial notebook** (separate issue/PR). New
    notebook `docs/tutorials/bridging.ipynb` (or similar) walking through
    several worked cases: untempered, `LikelihoodBridgeViaForm` under
    `Identity` link, `LikelihoodBridgeViaForm` under `LogSoftplus` link,
@@ -642,16 +720,13 @@ this is now a materially larger refactor than the original issue scoped.
    Covers the documentation requirement; the notebook is the primary
    artefact for "bridging × emulators × acquisitions interaction"
    understanding.
-9. **Phase 9 — link-aware acquisition audit** (separate issue/PR).
-   Audit acquisitions for tail-sensitivity introduced by exp link;
-   introduce link-aware variants of EI / VBMC-style acquisitions where
-   the closed-form depends on the link choice.
+10. **Phase 9 — link-aware acquisition audit** (separate issue/PR).
+    Audit acquisitions for tail-sensitivity introduced by exp link;
+    introduce link-aware variants of EI / VBMC-style acquisitions where
+    the closed-form depends on the link choice.
 
-Phases 2 and 3 are tightly coupled but worth separating: Phase 2's
-infrastructure can land and be unit-tested in isolation (test the maps,
-the pushforward dispatch); Phase 3 wires them into the existing form
-hierarchy. Phases 6 and 7 can land in either order. Phase 8 lands
-incrementally as 6/7 enable each scenario.
+Phases 6 and 7 can land in either order. Phase 8 lands incrementally
+as 6/7 enable each scenario.
 
 ## 10. Open questions
 
@@ -660,43 +735,47 @@ incrementally as 6/7 enable each scenario.
    everywhere via a prior or an output transform, but this gives back
    the non-negativity constraint we were trying to avoid. Defer to
    Phase 7.
-2. **Per-`Problem` vs per-run link choice.** Is the `link` a property
-   of the `Problem` (the user picks it once) or a per-run config (the
-   runner sweeps it for ablation)? Default: `Problem` carries it (via
-   the form's `link` field), but the runner can override for ablation
-   by constructing a copy of the problem with a different form.
-3. **Heteroskedastic forward models.** Forms where the likelihood depends
-   on $x$ multiplicatively (e.g. $\log\mathcal{N}(\mathrm{obs} \mid f(x),
-   C(x))$ with $x$-dependent noise covariance) violate the
-   "additive x-shift only" constraint. The shape of `DensityForm` doesn't
-   support this directly. Users with this case can subclass `DensityForm`
-   and override `__call__` / `pushforward`; no abstraction in the base
-   needs to bend. Worth a paragraph in the user-facing docs, not a
-   feature in v1.
-4. **Default `link` and `shift` arguments.** Should `DensityForm()` with
-   no arguments give `link=Identity(), shift=Constant(0)` (a
-   log-density-emulator form)? It's the "simplest" default, but may
-   confuse users who expect to specify a prior. Lean toward requiring
-   explicit `link` (no default) but defaulting `shift=Constant(0)`.
+2. **Per-`Problem` vs per-run link choice.** Resolved by [PR #63](https://github.com/arob5/sabi/pull/63):
+   the `DensityDecomposition` lives on `Algorithm`, not `Problem`. The
+   user constructs a decomposition and pairs it with a benchmark at
+   algorithm-construction time; ablations are handled by passing a
+   different decomposition to the runner.
+3. **Heteroskedastic forward models.** Decompositions where the
+   likelihood depends on $x$ multiplicatively (e.g. $\log\mathcal{N}(\mathrm{obs}
+   \mid f(x), C(x))$ with $x$-dependent noise covariance) violate the
+   "additive x-shift only" constraint. The shape of
+   `DensityDecomposition` doesn't support this directly. Users with
+   this case can subclass `DensityDecomposition` and override
+   `__call__` / `pushforward`; no abstraction in the base needs to
+   bend. Worth a paragraph in the user-facing docs, not a feature in v1.
+4. **Default `link` and `shift` arguments.** PR #63 defaults
+   `shift=Constant(0.0)` on `DensityDecomposition` and requires explicit
+   `link`. That matches the lean here.
 5. **Bijector unification.** When ProbPipe's bijectors land as a `Map`
    subclass, can sabi's `Map` ABC be the same? Likely yes; revisit when
    ProbPipe ships.
 
 ## 11. Composition with adjacent issues
 
+- **[PR #63](https://github.com/arob5/sabi/pull/63) — `TargetDistribution`
+  / `DensityDecomposition` split.** Sibling design PR. Hosts the
+  `DensityDecomposition` class this PR's `link` / `shift` machinery
+  plugs into; recommended landing order is in
+  [§9](#9-phasing-and-follow-up-issues).
 - **#3 — input/output transforms.** Output-side warps (e.g. an affine
-  standardisation of `Y_train`) sit *between* the emulator and the form
-  in the layer chain. A learned warp composed with `link=Identity()`
-  can recover softplus-like behaviour, but the abstractions are
-  conceptually distinct — the form's link is a fixed mathematical
-  relationship, the warp is a learned change of variables.
+  standardisation of `Y_train`) sit *between* the emulator and the
+  decomposition in the layer chain. A learned warp composed with
+  `link=Identity()` can recover softplus-like behaviour, but the
+  abstractions are conceptually distinct — the decomposition's link is
+  a fixed mathematical relationship, the warp is a learned change of
+  variables.
 - **#50 — noisy targets.** Both touch the pushforward dispatch. The
   noise enters by perturbing the emulator's predictive at observed
-  points; the form's `link` is downstream of that. The closed-form
-  pushforward registrations in [§5.1](#51-dispatch-table) must compose
-  with whatever noise model #50 lands. Designing the form abstraction
-  first means the noise work has fewer link-specific decisions to
-  make.
+  points; the decomposition's `link` is downstream of that. The
+  closed-form pushforward registrations in [§5.1](#51-dispatch-table)
+  must compose with whatever noise model #50 lands. Designing the
+  decomposition abstraction first means the noise work has fewer
+  link-specific decisions to make.
 - **#4 — `update_emulator` cheap-path dispatch.** The emulator-update
   optimisation interacts with `LikelihoodBridgeViaTargetRescale`: when
   only $Y_\mathrm{train}$ is rescaled, a cheap update is possible.

--- a/docs/link_functions.md
+++ b/docs/link_functions.md
@@ -1,0 +1,704 @@
+# Link functions and bridging — design proposal
+
+**Status:** draft v0.2 — pre-implementation
+**Issue:** [#55](https://github.com/arob5/sabi/issues/55)
+**Last updated:** 2026-05-06
+
+> Proposal for two coupled refactors:
+>
+> 1. Generalise sabi's emulated quantity beyond log-density. Today every
+>    `LogDensityForm` returns an unnormalised log-posterior, with `density ∝
+>    exp(form_output)` applied implicitly downstream. We replace this with an
+>    explicit **link function** abstraction: `density ∝ link(g(x))` for `link
+>    ∈ {exp, softplus, square, …}`.
+> 2. Reframe `TemperingScheme` as `BridgingScheme` — the operative concept is a
+>    *family of intermediate distributions between an initial and target
+>    distribution*, of which likelihood tempering is one instance. Several
+>    redundant abstractions collapse under this framing.
+>
+> The two refactors are coupled because the bridge's interaction with non-exp
+> links surfaces dispatch decisions that didn't exist before (e.g.,
+> "via-target-rescale" tempering only works under exp link). Doing them in one
+> design pass avoids re-litigating the form/link API when the bridging
+> rewrite lands.
+>
+> This is a **design-only** PR: no source code changes. Implementation is split
+> across follow-up issues (see [§9](#9-phasing-and-follow-up-issues)).
+>
+> Sabi's API is not yet stable; this proposal does not preserve back-compat
+> with current names or signatures.
+
+## 1. Motivation
+
+The exponential link is the default not because it is best, but because it is
+implicit. Every form in
+[`src/sabi/problems/forms.py`](../src/sabi/problems/forms.py) returns a value
+$g(x)$ that is interpreted as $\log p(x)$, and the consumer (ProbPipe MCMC,
+`Weights.log_weights` softmax) applies $\exp$ to recover an unnormalised
+density. Sabi never calls `exp` itself — but the assumption is everywhere.
+
+The exp link has well-known instabilities:
+
+- **Tail blow-up.** Small perturbations in the emulator's mean translate to
+  multiplicative blow-up in density when $\log p$ is large. A GP uncertainty
+  band of $\pm 2$ around $\log p = 30$ is densities differing by $e^4 \approx
+  55\times$.
+- **Pushforward variance.** Pushing a Gaussian through `exp` gives a log-normal
+  whose mean and variance are dominated by the upper tail of the Gaussian. The
+  bias note in
+  [`src/sabi/surrogate/estimators.py:15`](../src/sabi/surrogate/estimators.py)
+  is a direct symptom: the plug-in mean estimator is biased because of exactly
+  this tail-domination.
+- **Acquisition behaviour.** Acquisitions that integrate the surrogate against
+  a posterior weight inherit the same tail sensitivity.
+- **GP fitting.** Log-densities span huge dynamic range — often hundreds of
+  nats. A stationary-kernel GP struggles to fit a function ranging over
+  $[-300, 0]$ with sharp falloff. Output-scaling helps with the symptom; the
+  underlying issue (`exp` couples small fitting errors to large density errors)
+  remains.
+
+Alternative links (softplus, square) preserve non-negativity of density while
+giving the emulated quantity a more compact range. The motivation for the
+abstraction is thus narrow: **let the user choose what quantity the emulator
+fits, with `log-likelihood` (the current default, exp link) as one option
+among several**.
+
+## 2. Current state map
+
+The implicit-exp assumption is baked into the following sites. Any link
+abstraction must intercept all of them.
+
+| Site | What it does | Why it's exp-bound |
+|------|--------------|---------------------|
+| [`src/sabi/problems/forms.py`](../src/sabi/problems/forms.py) | `LogDensityForm` family — `Identity`, `LogLikPlusPrior`, `ForwardModel` | Return value is documented as "unnormalised log-posterior". |
+| [`src/sabi/surrogate/_pushforward.py:79`](../src/sabi/surrogate/_pushforward.py) | `pushforward_marginal` Gaussian-affine closed form | Closed form preserves Gaussianity by shifting `loc`; only valid because the form is *additive* in log-density space. |
+| [`src/sabi/surrogate/estimators.py:129`](../src/sabi/surrogate/estimators.py) | `_ExpectedTargetDistribution._unnormalized_log_prob` plug-in mean | Plugs emulator's predictive mean into form, treats result as log-density. |
+| [`src/sabi/surrogate/weighted_empirical.py:64`](../src/sabi/surrogate/weighted_empirical.py) | `WeightedEmpiricalRandomMeasure` log-weights | Weights consumed via softmax in ProbPipe `Weights` — assumes log-space input. |
+| [`src/sabi/target_distribution.py:56`](../src/sabi/target_distribution.py) | `TargetDistribution._unnormalized_log_prob` | ProbPipe `SupportsUnnormalizedLogProb` boundary — MCMC expects log-density. |
+| [`src/sabi/tempering/likelihood.py`](../src/sabi/tempering/likelihood.py) | `_LogLikPlusPriorTempered`, `_ForwardModelTempered`, `_IdentityTempered` | All do `β·log_likelihood_term`; tempering composes additively in log-space (see [§8](#8-bridging)). |
+
+The `WeightedEmpiricalRandomMeasure` site is link-agnostic in practice: weights
+are computed *outside* the class via the form, so the class only sees the
+already-converted log-weights. The other five sites all directly compose with
+form output.
+
+## 3. The `Link` abstraction
+
+A `Link` is the function $\ell$ that maps the emulator's output $g(x)$ to an
+unnormalised likelihood (or density, depending on the form). It carries two
+methods plus an inverse:
+
+```python
+class Link(ABC):
+    def link(self, g: Array) -> Array: ...        # g → unnormalised lik/density
+    def log_link(self, g: Array) -> Array: ...    # g → log unnormalised lik/density
+                                                  # (numerically stable; not log(link(g)))
+    def inv_link(self, d: Array) -> Array: ...    # unnormalised lik/density → g
+                                                  # (used at construction / reference targets)
+```
+
+The four candidate concrete links:
+
+### 3.1 `ExpLink` — the status quo, in disguise
+
+$$\ell(g) = \exp(g),\quad \log\ell(g) = g,\quad \ell^{-1}(d) = \log(d).$$
+
+The fact that `log_link` is the identity is exactly why the current codebase
+doesn't have to call any link function: the emulator emits $g(x) = \log
+\mathrm{lik}(x)$ directly, and the form returns log-density without applying
+any transformation.
+
+**The most important sentence in this whole document:** under `ExpLink`, *$g$
+is log-likelihood* (or log-posterior, depending on the form). Choosing
+`ExpLink` is equivalent to "the emulator fits log-likelihood / log-posterior",
+which is the common case and the current behaviour.
+
+### 3.2 `SoftplusLink`
+
+$$\ell(g) = \log(1 + e^g),\quad \log\ell(g) = \log\log(1 + e^g),\quad
+\ell^{-1}(d) = \log(e^d - 1).$$
+
+Range: $(0, \infty)$. Behaves like $\exp(g)$ for $g \ll 0$ (preserving
+log-likelihood tail-decay) and like $g$ for $g \gg 0$ (much milder dynamic
+range). Smooth and differentiable everywhere; non-negative without any
+constraint on $g$.
+
+The emulator now fits $g(x) = \mathrm{softplus}^{-1}(\mathrm{lik}(x))$, *not*
+log-likelihood. In the high-density region, $g$ has a compact range; in the
+tails, $g \approx \log\mathrm{lik}$. Tighter GP fits in the high-density
+region are the qualitative argument for softplus.
+
+Pushforward of $\mathcal{N}(\mu, \sigma^2)$: no closed form. Stable
+approximations: Gauss–Hermite quadrature for low-order moments; Monte Carlo
+via the existing MC fallback in `pushforward_marginal`.
+
+### 3.3 `SquareLink`
+
+$$\ell(g) = g^2,\quad \log\ell(g) = 2\log|g|,\quad \ell^{-1}(d) = \sqrt{d}.$$
+
+Range: $[0, \infty)$. Differentiable, but $\log\ell$ has a singularity at
+$g = 0$. Has a clean Hellinger / $L^2$-geometry interpretation and connects
+to the warped-GP literature for non-negative quantities; also appears in
+Bayesian-quadrature work (Osborne et al.).
+
+The emulator fits $g(x) = \sqrt{\mathrm{lik}(x)}$ (with sign).
+
+Pushforward of $\mathcal{N}(\mu, \sigma^2)$ through $g^2$ is a scaled
+non-central chi-squared with one degree of freedom and noncentrality
+parameter $\lambda = (\mu/\sigma)^2$ — closed-form moments and density.
+
+**Sign-convention drawback:** density is invariant under $g \mapsto -g$. The
+emulator's $g$ is identifiable only up to a global sign per disconnected
+support component. Practical implementations pin a sign convention (e.g.
+$g \ge 0$ via a prior or an output transform that absorbs the sign).
+Multimodal posteriors with disconnected high-density regions are a known
+failure mode worth flagging.
+
+### 3.4 `SigmoidLink` (for density ratios)
+
+$$\ell(g) = \sigma(g) = \frac{1}{1 + e^{-g}}.$$
+
+Range $(0, 1)$. Less natural for unnormalised densities (which are unbounded
+above), but fits when sabi is used to emulate a *density ratio* — a
+likelihood relative to a reference, or a posterior relative to the prior —
+where the natural range is bounded. Listed for completeness; the design
+must not preclude it but does not need to ship it in the first cut.
+
+### 3.5 Identity-with-positivity (ruled out)
+
+$\ell(g) = \max(g, 0)$ is non-differentiable at zero, which breaks
+GP-machinery composition. Smooth approximations *are* softplus and square.
+Not pursued.
+
+## 4. The `DensityForm` abstraction
+
+`LogDensityForm` is renamed to `DensityForm` and its base contract reduces
+to:
+
+```python
+class DensityForm(ABC):
+    def _call_single(self, x, y, *, prior) -> Array:
+        """Return the unnormalised log-density at x given emulator output y."""
+```
+
+This is the abstraction in your first requirement: *"an underlying emulator
+and a function that transforms the emulator target to obtain (log)
+unnormalised density."* Every form is "emulator + transformation function";
+the link is one factorisation of the transformation, not a universal field.
+
+Three concrete subclasses, with renaming:
+
+### 4.1 `Identity`
+
+```python
+@dataclass(frozen=True)
+class Identity(DensityForm):
+    """Emulator emits g(x); density(x) ∝ link(g(x)). No prior involvement."""
+    link: Link
+
+    def _call_single(self, x, y, *, prior=None) -> Array:
+        return self.link.log_link(y)
+```
+
+Under `ExpLink`: $g(x) = \log p(x)$, the form returns $y$ unchanged. Same as
+today's `Identity`.
+
+Under `SoftplusLink`: emulator fits $g(x) = \mathrm{softplus}^{-1}(p(x))$;
+form returns $\log\log(1 + e^y)$.
+
+### 4.2 `LikelihoodWithPrior`
+
+(Renamed from `LogLikPlusPrior`.)
+
+```python
+@dataclass(frozen=True)
+class LikelihoodWithPrior(DensityForm):
+    """Emulator emits g(x); likelihood(x) ∝ link(g(x)); density = link(g(x)) · prior(x)."""
+    link: Link
+
+    def _call_single(self, x, y, *, prior) -> Array:
+        return self.link.log_link(y) + log_prob(prior, x)
+```
+
+Under `ExpLink`: $g(x) = \log L(x)$, form returns $y + \log\pi_0(x)$. Same as
+today's `LogLikPlusPrior`.
+
+Under `SoftplusLink`: emulator fits $g(x) = \mathrm{softplus}^{-1}(L(x))$;
+form returns $\log\log(1 + e^y) + \log\pi_0(x)$.
+
+### 4.3 `ForwardModel` (link-free by design)
+
+```python
+@dataclass(frozen=True)
+class ForwardModel(DensityForm):
+    """Emulator emits forward-model output y; user-supplied likelihood does the rest."""
+    log_lik_from_outputs: Callable[[Array, Array], Array]
+
+    def _call_single(self, x, y, *, prior) -> Array:
+        return self.log_lik_from_outputs(x, y) + log_prob(prior, x)
+```
+
+`ForwardModel` does not carry a `Link`. The reason: the emulator's output is a
+forward-model quantity (e.g. simulated observations), not a density-related
+quantity. The user-supplied `log_lik_from_outputs` already absorbs whatever
+likelihood model they want to apply. The link concept describes *"how the
+emulator's output relates to density"* — and for forward-model emulation,
+that mapping lives entirely inside the user's likelihood code.
+
+This is not an awkward exception: `ForwardModel` is still a `DensityForm`
+(satisfies the same `_call_single` contract) and integrates with downstream
+machinery identically. It just doesn't expose a link as a separate axis.
+
+(For users who want to fit a non-log likelihood — e.g. emulate
+$\sqrt{\mathrm{lik}}$ via `ForwardModel` — they write
+`log_lik_from_outputs(x, y) = 2 * log(abs(y))`, doing the link inside their
+code. This is mathematically equivalent to a `LikelihoodWithPrior(SquareLink)`
+where the emulator fits $\sqrt{L}$. The two paths are alternatives, not in
+conflict.)
+
+## 5. Map-based pushforward dispatch
+
+The current `pushforward_marginal(input_dist, form, X, prior)` collapses
+several distinct transformations into one function. To support both
+non-exp links *and* the acquisition flexibility your second requirement asks
+for, we factor the transformations into separate `Map` objects and reify
+pushforward as multiple-dispatch on `(Map, Distribution)`.
+
+This is also the abstraction ProbPipe is converging on for its
+transport-map / pushforward op. By building it locally now, the eventual
+swap to ProbPipe's primitive is a class-rename, not a refactor.
+
+### 5.1 The `Map` abstraction
+
+```python
+class Map(ABC):
+    """A measurable function. Pushforwards dispatch on (Map, Distribution) types."""
+    def __call__(self, x: Array) -> Array: ...
+```
+
+Concrete maps for the link / form machinery, named for their mathematical
+content (not their role in sabi):
+
+| Map | $f(x)$ | Used for |
+|-----|--------|----------|
+| `Identity` | $x$ | `ExpLink.log_link` (the no-op case); identity pushforward |
+| `Log` | $\log x$ | `ExpLink.inv_link`; numerically risky in tails |
+| `Softplus` | $\log(1 + e^x)$ | `SoftplusLink.link` |
+| `LogSoftplus` | $\log\log(1 + e^x)$ | `SoftplusLink.log_link` (numerically stable form) |
+| `Square` | $x^2$ | `SquareLink.link` |
+| `LogSquare` | $2\log|x|$ | `SquareLink.log_link` (numerically stable form) |
+| `Sigmoid`, `LogSigmoid` | $\sigma(x)$, $\log\sigma(x)$ | `SigmoidLink` family |
+| `Affine(a, b)` | $a \cdot x + b$ | scaling + shift; covers "shift loc by log-prior" |
+
+Maps compose via `Compose(f, g)(x) = f(g(x))`. A link's `log_link` method
+returns the appropriate `Map`; the link's `link` method likewise returns a
+density-scale `Map`.
+
+The "add log-prior to a log-density" operation is *not* a separate map type —
+at fixed query point $x$, it's `Affine(a=1, b=log_prior(x))`. Across a batch
+of query points, it's a per-row `Affine` shift, which is just elementwise
+addition of a `Distribution` with a constant `Array`. ProbPipe will likely
+have a primitive for this (distribution + array → distribution); sabi's
+local stand-in is the existing `_shift_gaussian_loc` in
+[`src/sabi/surrogate/_pushforward.py:144`](../src/sabi/surrogate/_pushforward.py).
+
+### 5.2 The `pushforward` op
+
+```python
+def pushforward(map: Map, dist: Distribution) -> Distribution:
+    """Multiple-dispatch: closed form for known (Map, Distribution) pairs; MC fallback."""
+```
+
+Closed-form registrations land per (Map type, Distribution type):
+
+| Map | Distribution | Pushforward result |
+|-----|-------------|--------------------|
+| `Identity` | any | the same distribution |
+| `Affine(a, b)` | `Normal(loc, scale)` | `Normal(a·loc + b, |a|·scale)` |
+| `Affine(a, b)` | `MultivariateNormal(loc, scale_tril)` | `MultivariateNormal(a·loc + b, |a|·scale_tril)` |
+| `Square` | `Normal(loc, scale)` | scaled non-central chi-squared, df=1 |
+| `Log` | `Normal(loc, scale)` | log-normal |
+| `Softplus`, `LogSoftplus` | `Normal` | no closed form — falls through to MC |
+| `Compose(f, g)` | any | `pushforward(f, pushforward(g, dist))` |
+| (any) | `SupportsSampling` | MC fallback via the existing `_batch_form` machinery |
+
+The MC fallback is the existing `@workflow_function`-wrapped batched-form
+pattern, generalised: any callable wrapped with `@workflow_function` becomes
+a pushforward when handed a `Distribution` in a non-Distribution-typed slot.
+Sabi already does this for `_batch_form`; the `Map` abstraction just gives
+it a name.
+
+### 5.3 What this gets us
+
+The composition for "marginal random log-density at $X$" decomposes
+explicitly:
+
+```python
+emulator_predictive = emulator(X)                           # Distribution[Array]
+log_lik_predictive  = pushforward(form.link.log_link_map(),
+                                  emulator_predictive)      # Distribution[Array]
+log_density_predictive = log_lik_predictive + log_prior(X)  # Distribution[Array] + Array
+```
+
+Each line is a separate, named operation. Acquisitions that want to query
+intermediate layers (next subsection) get them by composing different maps.
+
+## 6. Acquisition customisation axes
+
+Many acquisitions admit two orthogonal customisation axes. The framework
+should make both consistent and discoverable.
+
+### 6.1 Axis 1 — which intermediate distribution to target
+
+Existing axis. `AcquisitionTarget` selects the bridging-state at which the
+acquisition's surrogate is built:
+
+- `CURRENT` — current round's intermediate (default).
+- `NEXT` — next round's intermediate (one-step look-ahead, SMC-flavour).
+- `TERMINAL` — final intermediate (always optimise toward the final target).
+
+This is unchanged by the link / bridging refactor — it sits at the
+algorithm level and is orthogonal to which layer is queried.
+
+### 6.2 Axis 2 — which predictive layer to target
+
+New axis, surfaced by the `Map`-dispatch design. A `SurrogateDistribution`
+(post-rename) exposes layered predictives:
+
+```python
+class SurrogateDistribution:
+    def emulator_predictive_at(self, X) -> Distribution: ...     # raw emulator
+    def pre_link_predictive_at(self, X) -> Distribution: ...     # = emulator (alias for clarity)
+    def log_density_predictive_at(self, X) -> Distribution: ...  # current pushforward_marginal
+    def density_predictive_at(self, X) -> Distribution: ...      # = pushforward(link.link_map, emulator)
+```
+
+(Aliasing `emulator_predictive_at` and `pre_link_predictive_at` makes both
+mental models accessible; the values are the same `Distribution`.)
+
+Acquisitions that vary on this axis carry it as a parameter:
+
+```python
+@dataclass
+class MaxVariance(Acquisition):
+    target_intermediate: AcquisitionTarget = AcquisitionTarget.CURRENT  # axis 1
+    target_layer: PredictiveLayer = PredictiveLayer.LOG_DENSITY         # axis 2
+
+    def acquire(self, sp: SurrogateDistribution, X_candidate: Array) -> Array:
+        match self.target_layer:
+            case PredictiveLayer.EMULATOR:    pred = sp.emulator_predictive_at(X_candidate)
+            case PredictiveLayer.LOG_DENSITY: pred = sp.log_density_predictive_at(X_candidate)
+            case PredictiveLayer.DENSITY:     pred = sp.density_predictive_at(X_candidate)
+        return variance(pred)
+```
+
+Acquisitions that *don't* vary along axis 2 (e.g. log-EI, where the
+log-density layer is fixed by definition) simply don't take the parameter.
+
+### 6.3 Naming
+
+```python
+class PredictiveLayer(Enum):
+    EMULATOR     = "emulator"      # raw emulator predictive
+    LOG_DENSITY  = "log_density"   # post-form, in log space
+    DENSITY      = "density"       # post-link, in density space
+```
+
+The two-axis structure should be documented prominently in
+`docs/acquisitions.md` (does not yet exist; would land alongside this work),
+and demonstrated end-to-end in the tutorial-notebook (see
+[§9](#9-phasing-and-follow-up-issues)).
+
+## 7. ProbPipe boundary — log-density at the MCMC seam
+
+Today, sabi exposes `TargetDistribution._unnormalized_log_prob(x) →
+log-density` to ProbPipe's `SupportsUnnormalizedLogProb` protocol. This is
+the only point where MCMC sees the form's output.
+
+Under the link abstraction, the boundary is unchanged: `_unnormalized_log_prob`
+returns log-density. Inside, the form composes
+`link.log_link(y) + log_prob(prior, x)` and returns the result. ProbPipe MCMC
+sees a log-density just like it does today.
+
+For some links (e.g. `square` near $g \approx 0$), $\log\ell(g) = 2\log|g|$ is
+numerically singular. The form must implement `log_link` carefully — but
+this is the link author's responsibility, not the boundary's.
+
+A second protocol (`SupportsUnnormalizedDensity` returning density-scale)
+could be added later if and when ProbPipe lands one. Sabi does not need it
+to ship link functions.
+
+## 8. Bridging
+
+(Renamed from "tempering". The mathematical concept is *bridging* — a
+parameterised path between an initial and a target distribution; tempering
+is one specific bridge family.)
+
+This section is intentionally long. Bridging is where the link choice
+interacts most subtly with existing machinery, and your second set of
+requirements asks for a clean abstraction that supports multiple bridge
+families and surfaces incompatible combinations as explicit errors.
+
+### 8.1 What's wrong with the current naming
+
+The current `TemperingScheme` is two abstractions in one:
+
+1. The mathematical *family of intermediate distributions* — defined by
+   $(\pi_0, \pi_\text{target}, \beta)$ for likelihood tempering, but the
+   concept generalises to other parametrisations.
+2. The algorithmic *strategy for realising the intermediate at each round* —
+   either by rebuilding the form (`ViaForm`) or by rescaling the emulator
+   target (`ViaTarget`).
+
+Conflating them means new bridge families inherit a `ViaForm`/`ViaTarget`
+distinction whether or not it makes sense for them, and link-compatibility
+dispatch (where some strategies only work under exp link) has nowhere clean
+to live.
+
+### 8.2 The new shape
+
+```python
+class BridgingScheme(ABC):
+    """Family of intermediate distributions parameterised by a state."""
+    initial: TargetDistribution
+    target:  TargetDistribution
+
+    def intermediate(self, state: Any) -> IntermediateTarget: ...
+    def is_invariant_target_map(self, state_a, state_b) -> bool: ...
+    def is_invariant_form(self, state_a, state_b) -> bool: ...
+```
+
+A `BridgingScheme` is defined purely in terms of (initial, target, state).
+Subclasses encode different bridge families *and* implementation strategies
+together, but with consistent naming that surfaces both axes:
+
+```python
+class LikelihoodBridgeViaForm(BridgingScheme):
+    """Likelihood bridge: π_β = π₀ · L^β. β factor enters via the form."""
+    # Works under any link. Form-axis tempering.
+
+class LikelihoodBridgeViaTargetRescale(BridgingScheme):
+    """Likelihood bridge: π_β = π₀ · L^β. β factor enters via Y_train rescaling."""
+    # Works ONLY under ExpLink. Target-axis tempering.
+    # Raises at intermediate_target() time if the base form's link is not ExpLink.
+```
+
+(The `Tempering` → `Bridging` rename is a search-and-replace across
+`src/sabi/tempering/` → `src/sabi/bridging/`, plus updating
+[`docs/tempering.md`](tempering.md) → `docs/bridging.md` with parallel
+content. Material churn but mechanical.)
+
+### 8.3 Why the via-target-rescale strategy needs ExpLink
+
+The mathematical family of likelihood bridges is
+
+$$\pi_\beta(x) \;\propto\; \pi_0(x) \cdot L(x)^\beta.$$
+
+The existing two strategies are equivalent under exp link because of the
+identity $\log L^\beta = \beta \log L$ — scaling the *log-likelihood* by
+$\beta$ is the same as raising the *likelihood* to power $\beta$.
+
+Under non-exp links, the emulator's output $g$ is no longer log-likelihood.
+For `SquareLink` ($g = \sqrt{L}$), raising likelihood to $\beta$ requires
+$g \mapsto g^\beta$, *not* $g \mapsto \beta g$. For `SoftplusLink`, there
+is no closed-form rescaling at all.
+
+So:
+
+- **`LikelihoodBridgeViaForm` works under any link.** The form's
+  `_call_single` is rebuilt per state to compute
+  $\beta \cdot \log\ell(g(x)) + \log\pi_0(x)$. This is link-aware *only*
+  in that it uses the link's `log_link` method, which already exists. The
+  $\beta$ factor multiplies the log-likelihood (not the emulator output);
+  this is well-defined for every link.
+- **`LikelihoodBridgeViaTargetRescale` only works under `ExpLink`.** The
+  rescaling $Y_\text{train} = \beta \cdot Y_\text{raw}$ is mathematically
+  equivalent to via-form *only* when $g$ is log-likelihood, i.e. under
+  exp link. Other links would need link-specific rescaling — which we could
+  add per-link later, but the obvious cases (square, softplus) don't have
+  cheap closed-form rescaling, so the via-target-rescale optimisation
+  is genuinely exp-link-specific.
+
+### 8.4 Error dispatch
+
+Per your third requirement, incompatible combinations raise informative
+errors at construction or scheme-application time. Concretely:
+
+```python
+class LikelihoodBridgeViaTargetRescale(BridgingScheme):
+    def intermediate(self, beta: float) -> IntermediateTarget:
+        link = self.target.density_form.link if hasattr(self.target.density_form, "link") else None
+        if not isinstance(link, ExpLink):
+            raise NotImplementedError(
+                f"LikelihoodBridgeViaTargetRescale requires the target form's link "
+                f"to be ExpLink, because Y_train = β·Y_raw is mathematically equivalent "
+                f"to via-form bridging only when g is log-likelihood. "
+                f"Got link={type(link).__name__}. "
+                f"Use LikelihoodBridgeViaForm (works under any link), or, if you want "
+                f"target-rescale optimisation under your link, file an issue describing "
+                f"the link-specific rescaling."
+            )
+        # ... existing target-rescale logic
+```
+
+`ForwardModel` doesn't expose a `link` attribute (it has none), so the
+isinstance check above fails the way we want — `ForwardModel` is
+incompatible with `LikelihoodBridgeViaTargetRescale` and the error message
+should say so.
+
+### 8.5 Form-by-form bridge math
+
+Per-form details for `LikelihoodBridgeViaForm`, with explicit reference to
+the link:
+
+| Base form | Tempered density (any link) | Form output at state $\beta$ |
+|-----------|------------------------------|--------------------------------|
+| `Identity(link)` | $\pi_0(x)^{1-\beta} \cdot \ell(g(x))^\beta$ — geometric bridge | $(1-\beta) \log\pi_0(x) + \beta \log\ell(g(x))$ |
+| `LikelihoodWithPrior(link)` | $\pi_0(x) \cdot \ell(g(x))^\beta$ | $\log\pi_0(x) + \beta \log\ell(g(x))$ |
+| `ForwardModel(log_lik_from_outputs)` | $\pi_0(x) \cdot \exp(\beta \cdot \mathrm{log\_lik\_from\_outputs}(x, y))$ | $\log\pi_0(x) + \beta \cdot \mathrm{log\_lik\_from\_outputs}(x, y)$ |
+
+The `Identity` case is the geometric bridge, identical to today's
+`_IdentityTempered`. The `LikelihoodWithPrior` case generalises today's
+`_LogLikPlusPriorTempered` to any link by routing through `link.log_link`
+instead of treating $g$ as log-likelihood directly. The `ForwardModel`
+case is unchanged from today's `_ForwardModelTempered` (no link involved).
+
+The three classes collapse into a single `_LikelihoodBridgedForm` plus a
+small per-form-type dispatch (or a `match` statement on the base form's
+type — sabi already uses `isinstance` dispatch in the bridging module).
+The total LoC is smaller than the current three-class implementation.
+
+### 8.6 Future bridge families
+
+`LikelihoodBridgeViaForm` is the first concrete bridge. Future families
+slot in alongside it without affecting the link abstraction:
+
+- `MixtureBridge`: $\pi_\beta = (1-\beta) \pi_0 + \beta \pi_\text{target}$.
+  Algebraically different (additive in densities, not multiplicative);
+  pushforward composes differently. Adds a new `BridgingScheme` subclass
+  with its own `intermediate` method.
+- `DataBridge`: $\pi_\beta(x) \propto \pi_0(x) \cdot \prod_{i \in S_\beta}
+  L_i(x)$ for some sequence of data subsets $S_\beta$. Adds a new
+  subclass; state PyTree is a subset index, not a scalar.
+
+Neither requires any change to `Link` or `DensityForm`. The bridge
+abstraction is link-agnostic in its mathematical content; link-compatibility
+checks live per-strategy.
+
+## 9. Phasing and follow-up issues
+
+This doc is the deliverable for **Phase 1** of the issue. Subsequent phases
+land in their own PRs / issues. The phasing acknowledges that this is now a
+materially larger refactor than the original issue scoped.
+
+1. **Phase 1 — design doc** (this PR). No code changes.
+2. **Phase 2 — `Link` + `Map` infrastructure** (separate issue/PR). Add
+   `Link` ABC and `ExpLink` concrete subclass; add `Map` ABC, concrete
+   maps (`Identity`, `Affine`, `Log`, etc.), `pushforward(Map,
+   Distribution)` multiple-dispatch op with closed-form registrations
+   and MC fallback. No form / surrogate / bridging changes yet — this
+   phase ships the primitives.
+3. **Phase 3 — `DensityForm` + form rename** (separate issue/PR).
+   `LogDensityForm` → `DensityForm`; `LogLikPlusPrior` →
+   `LikelihoodWithPrior`; add `link: Link` field to `Identity` and
+   `LikelihoodWithPrior`; rewrite `_call_single` bodies in terms of
+   `link.log_link`. `ForwardModel` unchanged. Behaviour-preserving for
+   all existing tests under `ExpLink`; benchmarks unchanged.
+4. **Phase 4 — surrogate layered predictive access** (separate
+   issue/PR). Add `SurrogateDistribution.{emulator,log_density,density}_predictive_at`
+   methods, all built on the Phase 2 pushforward op. Audit current
+   acquisitions for layer-access opportunities; introduce
+   `PredictiveLayer` enum and add `target_layer` parameter to acquisitions
+   that benefit (likely just `MaxVariance` for now).
+5. **Phase 5 — bridging rename + collapse** (separate issue/PR).
+   `sabi.tempering` → `sabi.bridging`; `TemperingScheme` →
+   `BridgingScheme`; collapse the three `_*Tempered` form classes into
+   one `_LikelihoodBridgedForm` with per-base-form dispatch;
+   `LikelihoodTemperingViaForm` → `LikelihoodBridgeViaForm`;
+   `LikelihoodTemperingViaTarget` → `LikelihoodBridgeViaTargetRescale`,
+   raising on non-exp link.
+6. **Phase 6 — `SoftplusLink`** (separate issue/PR). Concrete link with
+   numerically-stable `log_link` and `inv_link`; `LogSoftplus` map and
+   Gauss–Hermite or MC pushforward primitive; end-to-end test on a
+   synthetic 2D posterior comparing GP fit quality and posterior recovery
+   against `ExpLink`.
+7. **Phase 7 — `SquareLink`** (separate issue/PR). Concrete link with
+   sign-convention pinning; `LogSquare` and `Square` maps; non-central
+   chi-squared closed-form pushforward; benchmark validation.
+8. **Phase 8 — bridging tutorial notebook** (separate issue/PR). A new
+   notebook in `docs/` (or `docs/tutorials/`) that explores the bridging
+   abstraction across several worked cases: untempered loop,
+   `LikelihoodBridgeViaForm` under `ExpLink`, `LikelihoodBridgeViaForm`
+   under `SoftplusLink`, `LikelihoodBridgeViaTargetRescale` under
+   `ExpLink`, the failure mode of `LikelihoodBridgeViaTargetRescale +
+   SoftplusLink` (showing the error). Covers your documentation
+   requirement; the notebook is the primary artefact for
+   "bridging × emulators × acquisitions interaction" understanding.
+9. **Phase 9 — link-aware acquisition audit** (separate issue/PR). Audit
+   acquisitions for tail-sensitivity introduced by exp link; introduce
+   link-aware variants of EI / VBMC-style acquisitions where the
+   closed-form depends on the link choice.
+
+Phases 2 and 3 are tightly coupled but worth separating: Phase 2's
+`Link` + `Map` infrastructure can land and be tested in isolation
+(unit-test the maps, the pushforward dispatch); Phase 3 wires them into
+the existing form hierarchy without surprises. Phases 6 and 7 can land
+in either order. Phase 8 is the documentation artefact; consider
+landing pieces of it incrementally as Phases 6/7 enable each scenario.
+
+## 10. Open questions
+
+1. **Multimodal sign convention for square link.** How is $g$'s sign pinned
+   in the multimodal case? Most natural: assume $g \ge 0$ everywhere via a
+   prior or a transform, but this gives back the non-negativity constraint
+   we were trying to avoid. Defer to the square-link implementation PR
+   (Phase 7).
+2. **Per-`Problem` vs per-run link choice.** Is the link a property of the
+   `Problem` (the user picks it once) or a per-run config (the runner
+   sweeps it for ablation)? Default: `Problem` carries it (via the form's
+   `link` field), but the runner can override for ablation by constructing
+   a copy of the problem with a different form.
+3. **Inferred / learned links.** Out of scope; composes with #3 (input/output
+   transforms). Listed as a longer-term direction.
+4. **`ForwardModel` link variant.** Should there be a `ForwardModel` variant
+   that exposes a `Link`, where the user supplies $\mathrm{lik\_from\_outputs}
+   (x, y) \to \mathrm{pre\text{-}link\ likelihood}$ instead of
+   $\log L$? Current proposal: no — the user can do this inside their
+   existing `log_lik_from_outputs` callback. But if a use case emerges,
+   adding `ForwardModelWithLink` is additive.
+5. **`pre_link_predictive_at` vs `emulator_predictive_at` aliasing.** The
+   two names describe the same value (the emulator's predictive). Aliasing
+   is for clarity — does it instead introduce confusion? Could ship with
+   just `emulator_predictive_at` and let the docstring explain that it's
+   also "the pre-link distribution".
+
+## 11. Composition with adjacent issues
+
+- **#3 — input/output transforms.** Output-side warps (e.g. an affine
+  standardisation of `Y_train`) sit *between* the emulator and the link in
+  the layer chain. The link is "what the emulator's pre-warp output means
+  as a density"; the output transform is "what the emulator's training
+  input is, given a pre-link target value." A learned warp composed with
+  an exp link can recover softplus-like behaviour, but the abstractions
+  are conceptually distinct — the link is a fixed mathematical
+  relationship, the warp is a learned change of variables.
+- **#50 — noisy targets.** Both touch the pushforward dispatch. The noise
+  enters by perturbing the emulator's predictive at observed points; the
+  link is downstream of that. The closed-form pushforward registrations in
+  [§5.2](#52-the-pushforward-op) must compose with whatever noise model #50
+  lands. Designing the link abstraction first means the noise work has
+  fewer link-specific decisions to make.
+- **#4 — `update_emulator` cheap-path dispatch.** The emulator-update
+  optimisation interacts with `LikelihoodBridgeViaTargetRescale`: when only
+  $Y_\text{train}$ is rescaled, a cheap update is possible. With
+  link-compatibility error dispatch (only ExpLink supports the rescale),
+  the cheap-update path remains a clean optimisation.
+
+## 12. Style references
+
+- [`docs/design.md`](design.md) — overall sabi architecture.
+- [`docs/tempering.md`](tempering.md) — current tempering design (will be
+  rewritten as `docs/bridging.md` in Phase 5; this doc and that one
+  should be kept in sync after Phase 5).
+- [`docs/probpipe_random_measure_proposal.md`](probpipe_random_measure_proposal.md)
+  — proposal-style design doc that informed this one.


### PR DESCRIPTION
Closes #55 (Phase 1 only — design doc; implementation lands across follow-up issues).

## Summary

- Adds `docs/link_functions.md` (704 lines) — v0.2 design proposal covering two coupled refactors:
  1. **Link abstraction.** Generalize the emulated quantity beyond log-density. Today every form returns log-density and `density ∝ exp(form_output)` is implicit; this proposes an explicit `Link` (ExpLink / SoftplusLink / SquareLink / SigmoidLink). Under `ExpLink`, the emulator fits log-likelihood — same as today.
  2. **`TemperingScheme` → `BridgingScheme`.** Reframe so likelihood tempering is one bridge family among several future possibilities (mixture, data, ...). Collapses the three `_*Tempered` form classes into one bridged-form with per-base-form dispatch.
- Adds `link_functions` to the Concepts toctree in `docs/index.md`.

## Key design decisions

- **Map-based pushforward dispatch.** Each transformation in the chain (form's log_link, prior shift, density conversion) is a `Map`; `pushforward(Map, Distribution)` is multiple-dispatch. Built locally now; designed to swap for ProbPipe's pushforward primitive once that lands.
- **Two acquisition customization axes.** `AcquisitionTarget` (current/next/terminal intermediate, existing) × `PredictiveLayer` (emulator/log-density/density, new). `MaxVariance` and similar acquisitions take both as parameters.
- **`ForwardModel` is link-free by design.** The user's `log_lik_from_outputs` already absorbs whatever pre-density transformation they want; the link concept doesn't apply.
- **`LikelihoodBridgeViaTargetRescale` raises on non-exp link.** The `Y_train = β·Y_raw` optimization is mathematically equivalent to via-form bridging only when g is log-likelihood. Useful error surfaces the link-compatibility constraint.
- **Bridging tutorial notebook** is part of the phasing (Phase 8) — the bridging × emulators × acquisitions interaction is the most complex part of sabi and warrants worked-case documentation.

## Phasing (follow-up issues)

1. ✓ Phase 1 — design doc (this PR)
2. Phase 2 — `Link` + `Map` infrastructure
3. Phase 3 — `DensityForm` rename + `link` field on Identity / LikelihoodWithPrior
4. Phase 4 — surrogate layered predictive access + acquisition `target_layer`
5. Phase 5 — `sabi.tempering` → `sabi.bridging` rename + collapse
6. Phase 6 — `SoftplusLink`
7. Phase 7 — `SquareLink`
8. Phase 8 — bridging tutorial notebook
9. Phase 9 — link-aware acquisition audit

## Test plan

- [x] `uv run sphinx-build -W -b html docs docs/_build/html` succeeds with no warnings
- [x] New doc rendered in Concepts toctree
- [ ] Doc reviewed for technical accuracy and clarity
- [ ] Open questions in §10 resolved (or deferred to implementation phases) before Phase 2 begins
