### PR TITLE
feat(maps): Map ABC + pushforward(Map, Distribution) (#64)

### DIFF
--- a/src/sabi/maps/__init__.py
+++ b/src/sabi/maps/__init__.py
@@ -1,0 +1,44 @@
+"""sabi.maps — `Map` ABC, concrete maps, and `pushforward(map, dist)`.
+
+Phase 2 primitives from ``docs/link_functions.md``. The `Map`
+abstraction is intentionally aligned with what ProbPipe is converging
+on; sabi's local op becomes a re-export when ProbPipe lands.
+"""
+
+from sabi.maps._affine import Affine, Constant, Identity
+from sabi.maps._base import Compose, Map
+from sabi.maps._dirac import Dirac
+from sabi.maps._elementwise import (
+    Exp,
+    Log,
+    LogSoftplus,
+    LogSquare,
+    Softplus,
+    Square,
+)
+from sabi.maps._likelihood import GaussianLogLik, LogProb
+from sabi.maps._pushforward import pushforward
+
+__all__ = [
+    # ABC
+    "Map",
+    "Compose",
+    # Linear / constant
+    "Identity",
+    "Constant",
+    "Affine",
+    # Elementwise
+    "Exp",
+    "Log",
+    "Softplus",
+    "LogSoftplus",
+    "Square",
+    "LogSquare",
+    # Likelihood / log-prob
+    "GaussianLogLik",
+    "LogProb",
+    # Distribution shim
+    "Dirac",
+    # Dispatch op
+    "pushforward",
+]

--- a/src/sabi/maps/_affine.py
+++ b/src/sabi/maps/_affine.py
@@ -68,6 +68,18 @@ class Affine(Map):
     Shape ``() → ()``. ``slope`` and ``intercept`` are scalars (or
     arrays that broadcast against the input). Closed-form pushforward
     through Gaussians: see ``docs/link_functions.md`` §5.1.
+
+    The ``event_shape_*`` fields are scalar so that scalar-Map
+    composition (``Affine`` as one link in a ``Compose`` chain on
+    scalar emulator outputs) typechecks without bookkeeping. The
+    closed-form pushforward handlers in ``_pushforward.py`` also
+    accept vector ``intercept`` against an MVN — the shape contract
+    is enforced for ``Compose``, while pushforward broadcasting is
+    permissive at the registered-handler level. A vector-``Affine``
+    variant for first-class vector composition is left to the
+    link-function refactor (#65), which integrates ``Map`` with
+    ``DensityDecomposition`` and makes the layered shape semantics
+    fully explicit.
     """
 
     slope: Array = field(default_factory=lambda: jnp.asarray(1.0))

--- a/src/sabi/maps/_affine.py
+++ b/src/sabi/maps/_affine.py
@@ -1,0 +1,83 @@
+r"""`Identity`, `Constant`, and `Affine` — the linear / constant maps.
+
+These are the closed-form-friendly Maps: the
+:func:`pushforward(map, dist) <sabi.maps.pushforward>` op handles them
+analytically through Gaussians (and through arbitrary input
+distributions for `Identity` / `Constant`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import jax.numpy as jnp
+from jax import Array
+
+from sabi.maps._base import Map
+
+
+@dataclass(frozen=True)
+class Identity(Map):
+    r"""Identity map: :math:`f(z) = z`. Shape ``() → ()``.
+
+    Closed-form pushforward through any distribution: returns the input
+    distribution unchanged.
+    """
+
+    event_shape_in: tuple[int, ...] = ()
+    event_shape_out: tuple[int, ...] = ()
+
+    def __call__(self, z: Array) -> Array:
+        return z
+
+
+@dataclass(frozen=True)
+class Constant(Map):
+    r"""Constant map: :math:`f(z) = c`. Ignores ``z``.
+
+    ``event_shape_in = ()`` (declared scalar; broadcasting handles
+    batches regardless of input shape — a `Constant` ignores its
+    input). ``event_shape_out = c.shape``.
+    """
+
+    c: Array
+
+    def __post_init__(self) -> None:
+        # Coerce to a JAX array so c.shape is well-defined.
+        object.__setattr__(self, "c", jnp.asarray(self.c))
+
+    @property
+    def event_shape_in(self) -> tuple[int, ...]:
+        return ()
+
+    @property
+    def event_shape_out(self) -> tuple[int, ...]:
+        return tuple(self.c.shape)
+
+    def __call__(self, z: Array) -> Array:
+        # Broadcast c against z's leading batch dims. z.shape ==
+        # batch_shape + (), so broadcast_to(c, batch_shape + c.shape).
+        batch_shape = z.shape
+        return jnp.broadcast_to(self.c, batch_shape + self.c.shape)
+
+
+@dataclass(frozen=True)
+class Affine(Map):
+    r"""Affine map: :math:`f(z) = \mathrm{slope} \cdot z + \mathrm{intercept}`.
+
+    Shape ``() → ()``. ``slope`` and ``intercept`` are scalars (or
+    arrays that broadcast against the input). Closed-form pushforward
+    through Gaussians: see ``docs/link_functions.md`` §5.1.
+    """
+
+    slope: Array = field(default_factory=lambda: jnp.asarray(1.0))
+    intercept: Array = field(default_factory=lambda: jnp.asarray(0.0))
+    event_shape_in: tuple[int, ...] = ()
+    event_shape_out: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "slope", jnp.asarray(self.slope))
+        object.__setattr__(self, "intercept", jnp.asarray(self.intercept))
+
+    def __call__(self, z: Array) -> Array:
+        return self.slope * z + self.intercept

--- a/src/sabi/maps/_base.py
+++ b/src/sabi/maps/_base.py
@@ -1,0 +1,96 @@
+r"""`Map` ABC and the generic `Compose` combinator.
+
+A :class:`Map` is a single-variable measurable function with a declared
+shape contract. Maps participate in the
+:func:`pushforward(map, dist) <sabi.maps.pushforward>` multiple-dispatch
+op — closed-form pushforwards register against `Map` subclasses; an MC
+fallback handles the rest.
+
+See ``docs/link_functions.md`` §3 for the design intent and ProbPipe
+alignment, and ``docs/notation.md`` for the shape conventions.
+
+Shape contract
+--------------
+
+- ``event_shape_in``  — shape of one input event ``z``.
+- ``event_shape_out`` — shape of one output event ``f(z)``.
+- **Broadcasting.** Given input of shape
+  ``batch_shape + event_shape_in``, ``__call__`` returns
+  ``batch_shape + event_shape_out``. Same convention as
+  ``ArrayRandomFunction``.
+- **Composition.** ``f @ g`` requires
+  ``f.event_shape_in == g.event_shape_out``. Result has
+  ``event_shape_in == g.event_shape_in``,
+  ``event_shape_out == f.event_shape_out``.
+
+No ``inverse`` / ``log_det_jacobian`` slots — sabi's Maps are not
+required to be bijective. Bijectors will land in ProbPipe as a `Map`
+subclass that adds those slots.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from jax import Array
+
+
+class Map(ABC):
+    """Single-variable callable participating in pushforward dispatch.
+
+    Subclasses implement :meth:`__call__` and declare ``event_shape_in``
+    / ``event_shape_out`` (typically as dataclass fields or properties).
+    See the module docstring for the shape contract.
+    """
+
+    event_shape_in: tuple[int, ...]
+    event_shape_out: tuple[int, ...]
+
+    @abstractmethod
+    def __call__(self, z: Array) -> Array:
+        """Apply the Map. ``z.shape == batch_shape + event_shape_in``;
+        returns ``batch_shape + event_shape_out``.
+        """
+
+    def __matmul__(self, other: Map) -> Map:
+        r"""Composition: ``(f @ g)(z) = f(g(z))``.
+
+        Equivalent to ``Compose(self, other)``. Raises ``ValueError`` at
+        construction time if ``self.event_shape_in != other.event_shape_out``.
+        """
+        return Compose(self, other)
+
+
+@dataclass(frozen=True)
+class Compose(Map):
+    r"""Composition of two Maps: ``Compose(f, g)(z) = f(g(z))``.
+
+    Shape contract:
+
+    - ``event_shape_in  = g.event_shape_in``
+    - ``event_shape_out = f.event_shape_out``
+    - requires ``f.event_shape_in == g.event_shape_out`` at construction.
+    """
+
+    f: Map
+    g: Map
+
+    def __post_init__(self) -> None:
+        if self.f.event_shape_in != self.g.event_shape_out:
+            raise ValueError(
+                f"Compose: shape mismatch — f.event_shape_in="
+                f"{self.f.event_shape_in} but g.event_shape_out="
+                f"{self.g.event_shape_out}."
+            )
+
+    @property
+    def event_shape_in(self) -> tuple[int, ...]:
+        return self.g.event_shape_in
+
+    @property
+    def event_shape_out(self) -> tuple[int, ...]:
+        return self.f.event_shape_out
+
+    def __call__(self, z: Array) -> Array:
+        return self.f(self.g(z))

--- a/src/sabi/maps/_dirac.py
+++ b/src/sabi/maps/_dirac.py
@@ -14,8 +14,6 @@ becomes a re-export and eventually retires. Same migration shape as
 
 from __future__ import annotations
 
-from typing import Any
-
 import jax.numpy as jnp
 from jax import Array
 from probpipe.core._empirical import NumericEmpiricalDistribution
@@ -28,7 +26,7 @@ class Dirac(NumericEmpiricalDistribution):
     by :func:`sabi.maps.pushforward` for ``(Constant(c), *) → Dirac(c)``.
     """
 
-    def __init__(self, c: Array | Any, *, name: str = "dirac") -> None:
+    def __init__(self, c: Array, *, name: str = "dirac") -> None:
         c_arr = jnp.asarray(c)
         # Single-atom empirical: leading axis of size 1.
         super().__init__(samples=c_arr[None, ...], name=name)

--- a/src/sabi/maps/_dirac.py
+++ b/src/sabi/maps/_dirac.py
@@ -1,0 +1,41 @@
+r"""``Dirac`` — a degenerate point-mass Distribution shim.
+
+ProbPipe doesn't ship a ``Dirac`` (point-mass) distribution today; the
+existing ``_DiracArrayRandomFunction`` is a `RandomFunction` over ``x``,
+not a `Distribution`. The pushforward dispatch
+``(Constant(c), *) → Dirac(c)`` needs a Distribution, so this module
+provides a minimal one as a single-atom subclass of
+:class:`~probpipe.core._empirical.NumericEmpiricalDistribution`.
+
+Migration path: when ProbPipe ships a native ``Dirac``, this module
+becomes a re-export and eventually retires. Same migration shape as
+:mod:`sabi.surrogate._dirac`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+from jax import Array
+from probpipe.core._empirical import NumericEmpiricalDistribution
+
+
+class Dirac(NumericEmpiricalDistribution):
+    r"""Point mass at ``c``: a single-atom :math:`\delta_c` Distribution.
+
+    ``event_shape == c.shape``, ``mean == c``, ``variance == 0``. Used
+    by :func:`sabi.maps.pushforward` for ``(Constant(c), *) → Dirac(c)``.
+    """
+
+    def __init__(self, c: Array | Any, *, name: str = "dirac") -> None:
+        c_arr = jnp.asarray(c)
+        # Single-atom empirical: leading axis of size 1.
+        super().__init__(samples=c_arr[None, ...], name=name)
+        # Cache the atom for direct access (avoids unsqueezing on every call).
+        self._c = c_arr
+
+    @property
+    def c(self) -> Array:
+        """The atom location."""
+        return self._c

--- a/src/sabi/maps/_elementwise.py
+++ b/src/sabi/maps/_elementwise.py
@@ -1,0 +1,120 @@
+r"""Elementwise scalar Maps: ``Exp``, ``Log``, ``Softplus``,
+``LogSoftplus``, ``Square``, ``LogSquare``.
+
+Each has scalar shape ``() → ()`` and is a candidate ``link``-function
+for `DensityDecomposition` (per ``docs/link_functions.md`` §3.2). The
+``Log*`` variants are the numerically-stable log-of-the-base-map forms
+used when the corresponding ``link`` is what the emulator targets.
+
+Closed-form pushforward registrations (in
+:mod:`sabi.maps._pushforward`):
+
+- ``(Exp, Normal)`` → ``LogNormal``.
+- ``(Log, LogNormal)`` → ``Normal``.
+
+Everything else falls to the MC fallback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import jax.nn
+import jax.numpy as jnp
+from jax import Array
+
+from sabi.maps._base import Map
+
+
+@dataclass(frozen=True)
+class Exp(Map):
+    r""":math:`f(z) = e^z`. Shape ``() → ()``."""
+
+    event_shape_in: tuple[int, ...] = ()
+    event_shape_out: tuple[int, ...] = ()
+
+    def __call__(self, z: Array) -> Array:
+        return jnp.exp(z)
+
+
+@dataclass(frozen=True)
+class Log(Map):
+    r""":math:`f(z) = \log z`. Shape ``() → ()``.
+
+    Defined for ``z > 0``; behavior at non-positive inputs follows
+    ``jnp.log`` (returns ``-inf`` at 0, ``nan`` for negatives).
+    """
+
+    event_shape_in: tuple[int, ...] = ()
+    event_shape_out: tuple[int, ...] = ()
+
+    def __call__(self, z: Array) -> Array:
+        return jnp.log(z)
+
+
+@dataclass(frozen=True)
+class Softplus(Map):
+    r""":math:`f(z) = \log(1 + e^z)`. Shape ``() → ()``.
+
+    Numerically stable via :func:`jax.nn.softplus`. MC pushforward only.
+    """
+
+    event_shape_in: tuple[int, ...] = ()
+    event_shape_out: tuple[int, ...] = ()
+
+    def __call__(self, z: Array) -> Array:
+        return jax.nn.softplus(z)
+
+
+@dataclass(frozen=True)
+class LogSoftplus(Map):
+    r""":math:`f(z) = \log\log(1 + e^z)`. Shape ``() → ()``.
+
+    Numerically stable: writes
+    :math:`\log\log(1 + e^z) = \log(\mathrm{softplus}(z))`. MC
+    pushforward only.
+
+    Note: undefined for ``z`` such that ``softplus(z) = 0`` (i.e.,
+    very large negative inputs where softplus underflows). Callers are
+    responsible for keeping inputs in range.
+    """
+
+    event_shape_in: tuple[int, ...] = ()
+    event_shape_out: tuple[int, ...] = ()
+
+    def __call__(self, z: Array) -> Array:
+        return jnp.log(jax.nn.softplus(z))
+
+
+@dataclass(frozen=True)
+class Square(Map):
+    r""":math:`f(z) = z^2`. Shape ``() → ()``.
+
+    Falls to the MC fallback in this phase. The closed-form
+    non-central-:math:`\chi^2` pushforward of ``(Square, Normal)`` is
+    deferred to the square-link-end-to-end work
+    (``docs/link_functions.md`` §9, Phase 7).
+    """
+
+    event_shape_in: tuple[int, ...] = ()
+    event_shape_out: tuple[int, ...] = ()
+
+    def __call__(self, z: Array) -> Array:
+        return jnp.square(z)
+
+
+@dataclass(frozen=True)
+class LogSquare(Map):
+    r""":math:`f(z) = 2\log\lvert z\rvert`. Shape ``() → ()``.
+
+    Numerically stable form of ``Log @ Square``: avoids the explicit
+    ``z^2`` intermediate. Has a singularity at ``z = 0``; the
+    surrounding ``DensityDecomposition`` uses a ``NonNegative`` /
+    ``Positive`` constraint to keep callers away from it.
+    """
+
+    event_shape_in: tuple[int, ...] = ()
+    event_shape_out: tuple[int, ...] = ()
+
+    def __call__(self, z: Array) -> Array:
+        return 2.0 * jnp.log(jnp.abs(z))

--- a/src/sabi/maps/_likelihood.py
+++ b/src/sabi/maps/_likelihood.py
@@ -11,7 +11,7 @@ Both fall to the MC pushforward fallback (no closed-form registration).
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import jax.numpy as jnp
 from jax import Array
@@ -37,6 +37,9 @@ class GaussianLogLik(Map):
 
         \log\mathcal{N}(o \mid z, C) = -\tfrac{1}{2}(o - z)^\top C^{-1}
         (o - z) - \tfrac{1}{2}\log\lvert 2\pi C\rvert.
+
+    ``cov`` must be symmetric positive-definite; the formula assumes
+    a real, positive log-determinant.
     """
 
     obs: Array
@@ -56,13 +59,11 @@ class GaussianLogLik(Map):
 
     def __call__(self, z: Array) -> Array:
         diff = self.obs - z
-        sign, logdet = jnp.linalg.slogdet(self.cov)
-        # sign is +1 for SPD covariance; carrying it as a multiplicative
-        # factor preserves correct behavior if a non-SPD `cov` slips through.
+        _, logdet = jnp.linalg.slogdet(self.cov)
         d = self.obs.shape[0]
         solve = jnp.linalg.solve(self.cov, diff)
         quad = jnp.einsum("...i,...i->...", diff, solve)
-        return -0.5 * quad - 0.5 * (sign * logdet + d * jnp.log(2.0 * jnp.pi))
+        return -0.5 * quad - 0.5 * (logdet + d * jnp.log(2.0 * jnp.pi))
 
 
 @dataclass(frozen=True)
@@ -74,7 +75,7 @@ class LogProb(Map):
     ``dist == modeling_prior``.
     """
 
-    dist: Distribution = field()
+    dist: Distribution
     event_shape_out: tuple[int, ...] = ()
 
     @property
@@ -82,4 +83,4 @@ class LogProb(Map):
         return tuple(self.dist.event_shape)
 
     def __call__(self, z: Array) -> Array:
-        return jnp.asarray(log_prob(self.dist, z))
+        return log_prob(self.dist, z)

--- a/src/sabi/maps/_likelihood.py
+++ b/src/sabi/maps/_likelihood.py
@@ -1,0 +1,85 @@
+r"""``GaussianLogLik`` and ``LogProb`` — Maps that close over a
+distribution / likelihood at construction.
+
+These are non-elementwise: ``GaussianLogLik`` reduces a
+``(d,)``-dimensional input to a scalar log-likelihood; ``LogProb``
+reduces an ``event_shape``-dimensional input to a scalar log-probability
+under a closed-over distribution.
+
+Both fall to the MC pushforward fallback (no closed-form registration).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import jax.numpy as jnp
+from jax import Array
+from probpipe import log_prob
+from probpipe.core._distribution_base import Distribution
+
+from sabi.maps._base import Map
+
+
+@dataclass(frozen=True)
+class GaussianLogLik(Map):
+    r"""Gaussian log-likelihood map:
+    :math:`f(z) = \log\mathcal{N}(\mathrm{obs} \mid z, \mathrm{cov})`.
+
+    Shape ``(d,) → ()`` where ``d == obs.shape[0]``. Used by
+    forward-model decompositions: the emulator emits a
+    ``d``-dimensional output ``z`` (a simulated observation), and this
+    Map applies the Gaussian observation-model density.
+
+    The log-density is
+
+    .. math::
+
+        \log\mathcal{N}(o \mid z, C) = -\tfrac{1}{2}(o - z)^\top C^{-1}
+        (o - z) - \tfrac{1}{2}\log\lvert 2\pi C\rvert.
+    """
+
+    obs: Array
+    cov: Array
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "obs", jnp.asarray(self.obs))
+        object.__setattr__(self, "cov", jnp.asarray(self.cov))
+
+    @property
+    def event_shape_in(self) -> tuple[int, ...]:
+        return tuple(self.obs.shape)
+
+    @property
+    def event_shape_out(self) -> tuple[int, ...]:
+        return ()
+
+    def __call__(self, z: Array) -> Array:
+        diff = self.obs - z
+        sign, logdet = jnp.linalg.slogdet(self.cov)
+        # sign is +1 for SPD covariance; carrying it as a multiplicative
+        # factor preserves correct behavior if a non-SPD `cov` slips through.
+        d = self.obs.shape[0]
+        solve = jnp.linalg.solve(self.cov, diff)
+        quad = jnp.einsum("...i,...i->...", diff, solve)
+        return -0.5 * quad - 0.5 * (sign * logdet + d * jnp.log(2.0 * jnp.pi))
+
+
+@dataclass(frozen=True)
+class LogProb(Map):
+    r"""Closed-over log-probability: :math:`f(z) = \log p_\mathrm{dist}(z)`.
+
+    Shape ``dist.event_shape → ()``. Used as the ``shift`` Map in
+    `DensityDecomposition` to add a log-prior, with
+    ``dist == modeling_prior``.
+    """
+
+    dist: Distribution = field()
+    event_shape_out: tuple[int, ...] = ()
+
+    @property
+    def event_shape_in(self) -> tuple[int, ...]:
+        return tuple(self.dist.event_shape)
+
+    def __call__(self, z: Array) -> Array:
+        return jnp.asarray(log_prob(self.dist, z))

--- a/src/sabi/maps/_pushforward.py
+++ b/src/sabi/maps/_pushforward.py
@@ -1,0 +1,227 @@
+r"""``pushforward(map, dist)`` — multiple-dispatch pushforward op.
+
+Dispatches on ``(type(map), type(dist))``. Closed-form registrations
+land per pair via :func:`pushforward.register`; an MC fallback covers
+any ``(Map, SupportsSampling)`` not otherwise registered.
+
+For an input distribution :math:`F` and a Map :math:`f`, the pushforward
+is the distribution of :math:`f(Z)` where :math:`Z \sim F`. Closed-form
+entries (per ``docs/link_functions.md`` §5.1):
+
+- ``(Identity, *)`` — unchanged.
+- ``(Constant(c), *)`` — :class:`Dirac(c) <sabi.maps._dirac.Dirac>`.
+- ``(Affine, Normal)`` —
+  :math:`\mathcal{N}(\mathrm{slope}\cdot\mu + \mathrm{intercept},\
+  \lvert\mathrm{slope}\rvert\cdot\sigma)`.
+- ``(Affine, MultivariateNormal)`` —
+  :math:`\mathcal{N}(\mathrm{slope}\cdot\mu + \mathrm{intercept},\
+  \lvert\mathrm{slope}\rvert\cdot L)` where :math:`L` is ``scale_tril``.
+  (Scalar slope; sign carried as absolute value since the joint
+  covariance is the same either way.)
+- ``(Affine, NumericEmpiricalDistribution)`` — elementwise affine on
+  stored samples. Required for the ``Compose`` recursion through MC
+  intermediates (e.g. ``Affine ∘ LogSoftplus`` through an MVN).
+- ``(Exp, Normal)`` — :math:`\mathrm{LogNormal}(\mu, \sigma)`.
+- ``(Log, LogNormal)`` — :math:`\mathcal{N}(\mu, \sigma)`.
+- ``(Compose, *)`` — recurse:
+  ``pushforward(f, pushforward(g, dist))``.
+
+Anything else with a samplable input falls to the MC path: samples are
+drawn from the input distribution, the Map is applied per sample, and a
+:class:`~probpipe.core._empirical.NumericEmpiricalDistribution` of
+outputs is returned. This is the same machinery used by today's
+:func:`sabi.surrogate._pushforward._batch_form`, generalised from
+"form-specific MC" to "any Map".
+
+The dispatch table walks both type MROs and returns the most-derived
+match. New closed-form entries land via:
+
+.. code-block:: python
+
+    @pushforward.register(SomeMap, SomeDist)
+    def _pf_some(map: SomeMap, dist: SomeDist) -> Distribution:
+        ...
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import jax.numpy as jnp
+from jax import Array
+from probpipe.core._distribution_base import Distribution
+from probpipe.core._empirical import NumericEmpiricalDistribution
+from probpipe.core.node import workflow_function
+from probpipe.core.protocols import SupportsSampling
+from probpipe.distributions.continuous import LogNormal, Normal
+from probpipe.distributions.multivariate import MultivariateNormal
+
+from sabi.maps._affine import Affine, Constant, Identity
+from sabi.maps._base import Compose, Map
+from sabi.maps._dirac import Dirac
+from sabi.maps._elementwise import Exp, Log
+
+_Handler = Callable[[Map, Distribution], Distribution]
+
+
+class _PushforwardDispatch:
+    """Multiple-dispatch op keyed on ``(type(map), type(dist))``.
+
+    Lookup walks ``type(map).__mro__ × type(dist).__mro__`` lexicographically
+    (Map MRO outer, Distribution MRO inner) and returns the first
+    registered handler. The Map MRO drives outer ordering because
+    closed-form behavior is more strongly tied to the Map type than to
+    the input distribution type.
+    """
+
+    def __init__(self) -> None:
+        self._registry: dict[tuple[type, type], _Handler] = {}
+
+    def register(
+        self, map_cls: type[Map], dist_cls: type[Distribution]
+    ) -> Callable[[_Handler], _Handler]:
+        """Decorator: register a closed-form handler for the given
+        ``(map_cls, dist_cls)`` pair.
+        """
+        def decorator(handler: _Handler) -> _Handler:
+            self._registry[(map_cls, dist_cls)] = handler
+            return handler
+
+        return decorator
+
+    def _lookup(self, map_cls: type, dist_cls: type) -> _Handler | None:
+        for mc in map_cls.__mro__:
+            for dc in dist_cls.__mro__:
+                handler = self._registry.get((mc, dc))
+                if handler is not None:
+                    return handler
+        return None
+
+    def __call__(self, map_: Map, dist: Distribution) -> Distribution:
+        """Dispatch to the registered closed-form handler, or fall back
+        to MC for any ``(Map, SupportsSampling)`` input.
+
+        Args:
+            map_: the :class:`Map` to push samples through.
+            dist: the input distribution. For closed-form paths, must
+                match a registered ``(map_cls, dist_cls)`` pair; for the
+                MC fallback, must implement ``SupportsSampling``.
+
+        Returns:
+            The pushforward distribution.
+        """
+        handler = self._lookup(type(map_), type(dist))
+        if handler is not None:
+            return handler(map_, dist)
+        if isinstance(dist, SupportsSampling):
+            return _mc_pushforward(map_=map_, dist=dist)
+        raise NotImplementedError(
+            f"pushforward: no dispatch path for map={type(map_).__name__} "
+            f"and dist={type(dist).__name__}. Closed-form entries: see "
+            f"sabi.maps._pushforward; MC fallback requires SupportsSampling."
+        )
+
+
+pushforward = _PushforwardDispatch()
+
+
+# --------------------------------------------------------------------- #
+# Closed-form registrations
+# --------------------------------------------------------------------- #
+
+
+@pushforward.register(Identity, Distribution)
+def _pf_identity(map_: Identity, dist: Distribution) -> Distribution:
+    return dist
+
+
+@pushforward.register(Constant, Distribution)
+def _pf_constant(map_: Constant, dist: Distribution) -> Distribution:
+    return Dirac(map_.c)
+
+
+@pushforward.register(Affine, Normal)
+def _pf_affine_normal(map_: Affine, dist: Normal) -> Normal:
+    return Normal(
+        loc=map_.slope * dist.loc + map_.intercept,
+        scale=jnp.abs(map_.slope) * dist.scale,
+        name=dist.name + "_affine",
+    )
+
+
+@pushforward.register(Affine, MultivariateNormal)
+def _pf_affine_mvn(map_: Affine, dist: MultivariateNormal) -> MultivariateNormal:
+    return MultivariateNormal(
+        loc=map_.slope * dist.loc + map_.intercept,
+        scale_tril=jnp.abs(map_.slope) * dist.scale_tril,
+        name=dist.name + "_affine",
+    )
+
+
+@pushforward.register(Affine, NumericEmpiricalDistribution)
+def _pf_affine_empirical(
+    map_: Affine, dist: NumericEmpiricalDistribution
+) -> NumericEmpiricalDistribution:
+    """Elementwise affine on stored samples; weights and event_shape unchanged."""
+    return NumericEmpiricalDistribution(
+        samples=map_.slope * dist._samples + map_.intercept,
+        weights=dist._w,
+        name=dist.name + "_affine",
+    )
+
+
+@pushforward.register(Exp, Normal)
+def _pf_exp_normal(map_: Exp, dist: Normal) -> LogNormal:
+    return LogNormal(loc=dist.loc, scale=dist.scale, name=dist.name + "_exp")
+
+
+@pushforward.register(Log, LogNormal)
+def _pf_log_lognormal(map_: Log, dist: LogNormal) -> Normal:
+    return Normal(loc=dist.loc, scale=dist.scale, name=dist.name + "_log")
+
+
+@pushforward.register(Compose, Distribution)
+def _pf_compose(map_: Compose, dist: Distribution) -> Distribution:
+    """``pushforward(f @ g, dist) = pushforward(f, pushforward(g, dist))``."""
+    return pushforward(map_.f, pushforward(map_.g, dist))
+
+
+# --------------------------------------------------------------------- #
+# MC fallback
+# --------------------------------------------------------------------- #
+
+
+@workflow_function(n_broadcast_samples=64)
+def _apply_map(
+    *,
+    z: Array,
+    map_: Map,
+) -> Array:
+    """Apply ``map_`` to ``z``.
+
+    The Map's shape contract says ``z.shape == batch_shape +
+    event_shape_in`` produces ``batch_shape + event_shape_out``, so
+    no explicit ``jax.vmap`` is needed here — the per-sample shape
+    that ProbPipe passes is whatever the input distribution's event
+    sample looks like, which is already a valid Map input.
+
+    The MC pushforward arises when ProbPipe's
+    :class:`~probpipe.core.node.WorkflowFunction` broadcasting calls
+    this with ``z=input_dist`` (a ``Distribution`` in a non-``Distribution``
+    slot): samples are drawn from ``input_dist``, the function is run
+    per sample, and the result is a
+    :class:`~probpipe.core._empirical.NumericEmpiricalDistribution` of
+    Map outputs.
+    """
+    return map_(z)
+
+
+def _mc_pushforward(*, map_: Map, dist: Distribution) -> Distribution:
+    """MC pushforward via ProbPipe's
+    :class:`~probpipe.core.node.WorkflowFunction` broadcasting.
+
+    Passing ``z=dist`` triggers per-sample evaluation of ``map_`` over
+    samples drawn from ``dist``; the result is a
+    :class:`~probpipe.core._empirical.NumericEmpiricalDistribution`.
+    """
+    return _apply_map(z=dist, map_=map_)

--- a/src/sabi/maps/_pushforward.py
+++ b/src/sabi/maps/_pushforward.py
@@ -39,8 +39,14 @@ match. New closed-form entries land via:
 .. code-block:: python
 
     @pushforward.register(SomeMap, SomeDist)
-    def _pf_some(map: SomeMap, dist: SomeDist) -> Distribution:
+    def _pf_some(map_: SomeMap, dist: SomeDist) -> Distribution:
         ...
+
+The MC fallback's sample budget is fixed at ``n_broadcast_samples=64``,
+matching the precedent in
+:func:`sabi.surrogate._pushforward._batch_form`. Exposing it on the
+``_mc_pushforward`` boundary so downstream callers can dial it is left
+for the link-function / surrogate integration that follows this PR.
 """
 
 from __future__ import annotations
@@ -131,12 +137,12 @@ pushforward = _PushforwardDispatch()
 
 
 @pushforward.register(Identity, Distribution)
-def _pf_identity(map_: Identity, dist: Distribution) -> Distribution:
+def _pf_identity(map_: Identity, dist: Distribution) -> Distribution:  # noqa: ARG001
     return dist
 
 
 @pushforward.register(Constant, Distribution)
-def _pf_constant(map_: Constant, dist: Distribution) -> Distribution:
+def _pf_constant(map_: Constant, dist: Distribution) -> Distribution:  # noqa: ARG001
     return Dirac(map_.c)
 
 
@@ -145,7 +151,7 @@ def _pf_affine_normal(map_: Affine, dist: Normal) -> Normal:
     return Normal(
         loc=map_.slope * dist.loc + map_.intercept,
         scale=jnp.abs(map_.slope) * dist.scale,
-        name=dist.name + "_affine",
+        name=dist.name,
     )
 
 
@@ -154,7 +160,7 @@ def _pf_affine_mvn(map_: Affine, dist: MultivariateNormal) -> MultivariateNormal
     return MultivariateNormal(
         loc=map_.slope * dist.loc + map_.intercept,
         scale_tril=jnp.abs(map_.slope) * dist.scale_tril,
-        name=dist.name + "_affine",
+        name=dist.name,
     )
 
 
@@ -164,20 +170,20 @@ def _pf_affine_empirical(
 ) -> NumericEmpiricalDistribution:
     """Elementwise affine on stored samples; weights and event_shape unchanged."""
     return NumericEmpiricalDistribution(
-        samples=map_.slope * dist._samples + map_.intercept,
-        weights=dist._w,
-        name=dist.name + "_affine",
+        samples=map_.slope * dist.samples + map_.intercept,
+        log_weights=dist.log_weights,
+        name=dist.name,
     )
 
 
 @pushforward.register(Exp, Normal)
-def _pf_exp_normal(map_: Exp, dist: Normal) -> LogNormal:
-    return LogNormal(loc=dist.loc, scale=dist.scale, name=dist.name + "_exp")
+def _pf_exp_normal(map_: Exp, dist: Normal) -> LogNormal:  # noqa: ARG001
+    return LogNormal(loc=dist.loc, scale=dist.scale, name=dist.name)
 
 
 @pushforward.register(Log, LogNormal)
-def _pf_log_lognormal(map_: Log, dist: LogNormal) -> Normal:
-    return Normal(loc=dist.loc, scale=dist.scale, name=dist.name + "_log")
+def _pf_log_lognormal(map_: Log, dist: LogNormal) -> Normal:  # noqa: ARG001
+    return Normal(loc=dist.loc, scale=dist.scale, name=dist.name)
 
 
 @pushforward.register(Compose, Distribution)

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -1,0 +1,244 @@
+"""Tests for the `Map` ABC and concrete `Map` subclasses.
+
+The shape contract for `Map.__call__`: given input of shape
+``batch_shape + event_shape_in``, returns ``batch_shape + event_shape_out``.
+``Compose(f, g)`` requires ``f.event_shape_in == g.event_shape_out``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+from probpipe.distributions.continuous import Normal
+from probpipe.distributions.multivariate import MultivariateNormal
+
+from sabi.maps import (
+    Affine,
+    Compose,
+    Constant,
+    Exp,
+    GaussianLogLik,
+    Identity,
+    Log,
+    LogProb,
+    LogSoftplus,
+    LogSquare,
+    Softplus,
+    Square,
+)
+
+# -------------------------------------------------------------------------
+# Per-map __call__ correctness
+# -------------------------------------------------------------------------
+
+
+def test_identity_call_returns_input():
+    f = Identity()
+    z = jnp.asarray(0.7)
+    assert float(f(z)) == pytest.approx(0.7)
+
+
+def test_constant_call_returns_c_regardless_of_input():
+    c = jnp.asarray([1.0, -2.0])
+    f = Constant(c=c)
+    assert jnp.allclose(f(jnp.asarray(0.0)), c)
+    assert jnp.allclose(f(jnp.asarray(99.0)), c)
+
+
+def test_affine_call_matches_formula():
+    f = Affine(slope=2.0, intercept=-3.0)
+    z = jnp.asarray(5.0)
+    assert float(f(z)) == pytest.approx(2.0 * 5.0 - 3.0)
+
+
+def test_exp_call_matches_jnp_exp():
+    f = Exp()
+    z = jnp.asarray(1.5)
+    assert float(f(z)) == pytest.approx(float(jnp.exp(z)))
+
+
+def test_log_call_matches_jnp_log():
+    f = Log()
+    z = jnp.asarray(2.0)
+    assert float(f(z)) == pytest.approx(float(jnp.log(z)))
+
+
+def test_softplus_call_matches_jax_softplus():
+    f = Softplus()
+    z = jnp.asarray(-0.5)
+    assert float(f(z)) == pytest.approx(float(jax.nn.softplus(z)))
+
+
+def test_log_softplus_call_matches_log_of_softplus():
+    f = LogSoftplus()
+    z = jnp.asarray(0.5)
+    assert float(f(z)) == pytest.approx(float(jnp.log(jax.nn.softplus(z))))
+
+
+def test_square_call_matches_z_squared():
+    f = Square()
+    z = jnp.asarray(-3.0)
+    assert float(f(z)) == pytest.approx(9.0)
+
+
+def test_log_square_call_matches_2_log_abs_z():
+    f = LogSquare()
+    z = jnp.asarray(-2.0)
+    assert float(f(z)) == pytest.approx(2.0 * float(jnp.log(2.0)))
+
+
+def test_gaussian_log_lik_call_matches_normal_log_prob():
+    """`GaussianLogLik(obs, cov)(z) = log N(obs | z, cov)` agrees with
+    a TFP MVN's log_prob computed at obs with mean z."""
+    obs = jnp.asarray([1.0, 0.5])
+    cov = jnp.asarray([[2.0, 0.3], [0.3, 1.0]])
+    f = GaussianLogLik(obs=obs, cov=cov)
+    z = jnp.asarray([0.2, -0.4])
+    # Reference via MVN(z, cov).log_prob(obs)
+    ref = MultivariateNormal(loc=z, scale_tril=jnp.linalg.cholesky(cov), name="ref")
+    from probpipe import log_prob as pp_log_prob
+    expected = float(pp_log_prob(ref, obs))
+    assert float(f(z)) == pytest.approx(expected, abs=1e-5)
+
+
+def test_log_prob_call_matches_distribution_log_prob():
+    dist = Normal(loc=jnp.asarray(0.0), scale=jnp.asarray(1.0), name="p")
+    f = LogProb(dist=dist)
+    z = jnp.asarray(1.5)
+    expected = -0.5 * 1.5 ** 2 - 0.5 * float(jnp.log(2 * jnp.pi))
+    assert float(f(z)) == pytest.approx(expected, abs=1e-5)
+
+
+# -------------------------------------------------------------------------
+# event_shape_in / event_shape_out
+# -------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        Identity,
+        Exp,
+        Log,
+        Softplus,
+        LogSoftplus,
+        Square,
+        LogSquare,
+        lambda: Affine(slope=1.0, intercept=0.0),
+    ],
+)
+def test_scalar_maps_event_shapes_are_unit(factory):
+    f = factory()
+    assert f.event_shape_in == ()
+    assert f.event_shape_out == ()
+
+
+def test_constant_event_shapes_match_c_shape():
+    c = jnp.zeros((3, 2))
+    f = Constant(c=c)
+    assert f.event_shape_in == ()
+    assert f.event_shape_out == (3, 2)
+
+
+def test_gaussian_log_lik_event_shapes():
+    f = GaussianLogLik(obs=jnp.zeros(4), cov=jnp.eye(4))
+    assert f.event_shape_in == (4,)
+    assert f.event_shape_out == ()
+
+
+def test_log_prob_event_shapes_match_dist_event_shape():
+    dist = MultivariateNormal(loc=jnp.zeros(3), scale_tril=jnp.eye(3), name="p")
+    f = LogProb(dist=dist)
+    assert f.event_shape_in == (3,)
+    assert f.event_shape_out == ()
+
+
+# -------------------------------------------------------------------------
+# Batched-input broadcasting
+# -------------------------------------------------------------------------
+
+
+def test_scalar_map_broadcasts_over_leading_batch():
+    """Per the shape contract, calling ``f`` on shape
+    ``batch + event_shape_in`` returns ``batch + event_shape_out``."""
+    f = Affine(slope=3.0, intercept=1.0)
+    z = jnp.asarray([1.0, 2.0, 3.0])  # batch_shape == (3,)
+    out = f(z)
+    assert out.shape == (3,)
+    assert jnp.allclose(out, jnp.asarray([4.0, 7.0, 10.0]))
+
+
+def test_gaussian_log_lik_broadcasts_over_leading_batch():
+    """Map with ``event_shape_in == (d,)`` collapses each row."""
+    f = GaussianLogLik(obs=jnp.zeros(2), cov=jnp.eye(2))
+    Z = jnp.asarray([[0.0, 0.0], [1.0, 1.0], [-1.0, 0.5]])
+    out = jax.vmap(f)(Z)
+    assert out.shape == (3,)
+
+
+def test_constant_broadcasts_against_arbitrary_input_shape():
+    c = jnp.asarray([1.0, 2.0])
+    f = Constant(c=c)
+    z_batch = jnp.zeros((4,))
+    out = f(z_batch)
+    assert out.shape == (4, 2)
+    assert jnp.allclose(out[0], c)
+
+
+# -------------------------------------------------------------------------
+# Compose / @ operator
+# -------------------------------------------------------------------------
+
+
+def test_matmul_returns_compose():
+    f = Exp()
+    g = Affine(slope=2.0)
+    composed = f @ g
+    assert isinstance(composed, Compose)
+    assert composed.f is f
+    assert composed.g is g
+
+
+def test_compose_call_equals_f_of_g():
+    """``(f @ g)(z) == f(g(z))``."""
+    f = Exp()
+    g = Affine(slope=2.0, intercept=-1.0)
+    z = jnp.asarray(0.5)
+    expected = float(f(g(z)))
+    assert float((f @ g)(z)) == pytest.approx(expected, abs=1e-6)
+
+
+def test_compose_with_identity_is_no_op():
+    f = Affine(slope=3.0, intercept=2.0)
+    z = jnp.asarray(0.7)
+    assert float((f @ Identity())(z)) == pytest.approx(float(f(z)))
+    assert float((Identity() @ f)(z)) == pytest.approx(float(f(z)))
+
+
+def test_compose_associativity():
+    f = Exp()
+    g = Affine(slope=2.0, intercept=1.0)
+    h = LogSoftplus()
+    z = jnp.asarray(0.3)
+    left = f @ (g @ h)
+    right = (f @ g) @ h
+    assert float(left(z)) == pytest.approx(float(right(z)), abs=1e-6)
+
+
+def test_compose_event_shape_propagation():
+    g = GaussianLogLik(obs=jnp.zeros(3), cov=jnp.eye(3))
+    f = Affine(slope=2.0)
+    composed = f @ g
+    assert composed.event_shape_in == (3,)
+    assert composed.event_shape_out == ()
+
+
+def test_compose_shape_mismatch_raises():
+    """``f.event_shape_in == g.event_shape_out`` is required at construction."""
+    g = GaussianLogLik(obs=jnp.zeros(3), cov=jnp.eye(3))  # (3,) -> ()
+    f_bad = LogProb(
+        dist=MultivariateNormal(loc=jnp.zeros(2), scale_tril=jnp.eye(2), name="p")
+    )  # (2,) -> ()
+    with pytest.raises(ValueError, match="shape mismatch"):
+        Compose(f_bad, g)

--- a/tests/test_pushforward.py
+++ b/tests/test_pushforward.py
@@ -110,8 +110,8 @@ def test_affine_empirical_applies_elementwise_to_samples():
     )
     out = pushforward(Affine(slope=2.0, intercept=1.0), emp)
     assert isinstance(out, NumericEmpiricalDistribution)
-    expected = 2.0 * emp._samples + 1.0
-    assert jnp.allclose(out._samples, expected)
+    expected = 2.0 * emp.samples + 1.0
+    assert jnp.allclose(out.samples, expected)
 
 
 # -------------------------------------------------------------------------
@@ -172,22 +172,33 @@ def test_compose_recursion_matches_manual_chain():
 def test_compose_mixed_closed_then_mc_returns_empirical():
     """``Affine @ LogSoftplus`` through MVN: LogSoftplus falls to MC,
     Affine applies closed-form on the resulting empirical distribution.
-    Per ``docs/link_functions.md`` §5.4."""
+    Per ``docs/link_functions.md`` §5.4.
+
+    The test is qualitative: it confirms that the dispatch path produced
+    an empirical distribution of the right shape and that the
+    closed-form Affine actually scaled the per-coord variability (i.e.,
+    didn't collapse the empirical to a Dirac or leak intercept into
+    spread). Tighter quantitative claims would require seeding MC at a
+    fixed budget — both of which are deferred until the link-function
+    refactor exposes `n_broadcast_samples` on the pushforward boundary.
+    """
     L = jnp.eye(3)
     mvn = MultivariateNormal(loc=jnp.zeros(3), scale_tril=L, name="x")
     intercept = jnp.asarray([1.0, -1.0, 0.5])
-    m = Affine(slope=2.0, intercept=intercept) @ LogSoftplus()
+    slope = 2.0
+    m = Affine(slope=slope, intercept=intercept) @ LogSoftplus()
     out = pushforward(m, mvn)
     assert isinstance(out, NumericEmpiricalDistribution)
     assert out.event_shape == (3,)
-    # Each output coord is `2 * LogSoftplus(z_i) + intercept_i` with
-    # `z_i ~ N(0, 1)` iid. So the variance is `4 * Var[LogSoftplus(N(0,1))]`,
-    # the *same* across coords; subtracting the per-coord mean removes the
-    # intercept and leaves a stationary, zero-mean per-coord sample.
-    centered = out._samples - jnp.mean(out._samples, axis=0)
-    per_coord_var = jnp.var(centered, axis=0)
-    # All per-coord variances should be close to each other.
-    assert jnp.allclose(per_coord_var, per_coord_var[0], rtol=0.5)
+    # Each output coord is `slope * LogSoftplus(z_i) + intercept_i` with
+    # `z_i ~ N(0, 1)` iid, so per-coord variances are all equal to
+    # `slope^2 * Var[LogSoftplus(N(0,1))]`. With 64 samples per coord
+    # the per-coord variance estimator has relative SE ~ sqrt(2/64) ≈ 18%;
+    # a 2x rtol envelope covers seed-to-seed drift comfortably. The
+    # affine slope must not be swallowed: per-coord variance > 0.
+    per_coord_var = jnp.var(out.samples, axis=0)
+    assert jnp.all(per_coord_var > 1e-3)
+    assert jnp.allclose(per_coord_var, per_coord_var[0], rtol=1.0)
 
 
 # -------------------------------------------------------------------------
@@ -201,7 +212,7 @@ def test_mc_fallback_log_softplus_normal_returns_empirical():
     assert isinstance(out, NumericEmpiricalDistribution)
     assert out.event_shape == ()
     # All samples are finite: log(softplus(z)) is finite for z away from -inf.
-    assert jnp.all(jnp.isfinite(out._samples))
+    assert jnp.all(jnp.isfinite(out.samples))
 
 
 def test_mc_fallback_log_softplus_mvn_returns_empirical_with_correct_event_shape():

--- a/tests/test_pushforward.py
+++ b/tests/test_pushforward.py
@@ -1,0 +1,229 @@
+"""Tests for ``pushforward(map, dist)`` — the multiple-dispatch op.
+
+Two flavors of test per closed-form entry: (a) direct equality on the
+returned distribution's parameters; (b) Monte Carlo agreement, drawing
+samples from the closed-form output and checking that empirical
+mean/variance match the formula at ~5% slack
+(``docs/contributing.md`` §Tests).
+
+MC fallback paths are validated by sample-shape checks plus a sanity
+check that empirical moments are consistent with a hand-computed
+reference.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+from probpipe import sample
+from probpipe.core._empirical import NumericEmpiricalDistribution
+from probpipe.distributions.continuous import LogNormal, Normal
+from probpipe.distributions.multivariate import MultivariateNormal
+
+from sabi.maps import (
+    Affine,
+    Constant,
+    Dirac,
+    Exp,
+    Identity,
+    Log,
+    LogSoftplus,
+    pushforward,
+)
+
+# -------------------------------------------------------------------------
+# Closed-form: Identity
+# -------------------------------------------------------------------------
+
+
+def test_identity_pushforward_returns_input_unchanged():
+    n = Normal(loc=jnp.asarray(0.5), scale=jnp.asarray(1.5), name="x")
+    out = pushforward(Identity(), n)
+    assert out is n
+
+
+# -------------------------------------------------------------------------
+# Closed-form: Constant -> Dirac
+# -------------------------------------------------------------------------
+
+
+def test_constant_pushforward_returns_dirac_at_c():
+    c = jnp.asarray([1.0, -2.0, 0.5])
+    n = Normal(loc=jnp.asarray(0.0), scale=jnp.asarray(1.0), name="x")
+    out = pushforward(Constant(c=c), n)
+    assert isinstance(out, Dirac)
+    assert jnp.allclose(out.c, c)
+    assert out.event_shape == c.shape
+
+
+# -------------------------------------------------------------------------
+# Closed-form: (Affine, Normal)
+# -------------------------------------------------------------------------
+
+
+def test_affine_normal_returns_normal_with_shifted_loc_and_scaled_scale():
+    n = Normal(loc=jnp.asarray(2.0), scale=jnp.asarray(3.0), name="x")
+    out = pushforward(Affine(slope=-2.0, intercept=1.0), n)
+    assert isinstance(out, Normal)
+    assert float(out.loc) == pytest.approx(-2.0 * 2.0 + 1.0)
+    # |slope| · scale — sign goes into the absolute value
+    assert float(out.scale) == pytest.approx(2.0 * 3.0)
+
+
+def test_affine_normal_mc_moments_match_closed_form():
+    """Closed-form output samples should agree on mean/variance with
+    the MC pushforward (each at the same sample budget)."""
+    n = Normal(loc=jnp.asarray(0.5), scale=jnp.asarray(1.0), name="x")
+    out = pushforward(Affine(slope=2.0, intercept=-1.0), n)
+    key = jax.random.key(0)
+    s = sample(out, key=key, sample_shape=(20_000,))
+    assert float(jnp.mean(s)) == pytest.approx(2.0 * 0.5 - 1.0, abs=0.05)
+    assert float(jnp.std(s)) == pytest.approx(2.0 * 1.0, abs=0.05)
+
+
+# -------------------------------------------------------------------------
+# Closed-form: (Affine, MultivariateNormal)
+# -------------------------------------------------------------------------
+
+
+def test_affine_mvn_returns_mvn_with_shifted_loc_and_scaled_scale_tril():
+    L = jnp.asarray([[1.0, 0.0], [0.5, 0.8]])
+    mvn = MultivariateNormal(
+        loc=jnp.asarray([1.0, -1.0]), scale_tril=L, name="x"
+    )
+    intercept = jnp.asarray([0.5, 2.0])
+    out = pushforward(Affine(slope=3.0, intercept=intercept), mvn)
+    assert isinstance(out, MultivariateNormal)
+    assert jnp.allclose(out.loc, 3.0 * mvn.loc + intercept)
+    assert jnp.allclose(out.scale_tril, 3.0 * L)
+
+
+# -------------------------------------------------------------------------
+# Closed-form: (Affine, NumericEmpiricalDistribution)
+# -------------------------------------------------------------------------
+
+
+def test_affine_empirical_applies_elementwise_to_samples():
+    emp = NumericEmpiricalDistribution(
+        samples=jnp.asarray([[0.0, 1.0], [2.0, 3.0], [-1.0, 0.5]]), name="emp"
+    )
+    out = pushforward(Affine(slope=2.0, intercept=1.0), emp)
+    assert isinstance(out, NumericEmpiricalDistribution)
+    expected = 2.0 * emp._samples + 1.0
+    assert jnp.allclose(out._samples, expected)
+
+
+# -------------------------------------------------------------------------
+# Closed-form: (Exp, Normal) -> LogNormal
+# -------------------------------------------------------------------------
+
+
+def test_exp_normal_returns_lognormal_with_same_loc_scale():
+    n = Normal(loc=jnp.asarray(0.3), scale=jnp.asarray(0.7), name="x")
+    out = pushforward(Exp(), n)
+    assert isinstance(out, LogNormal)
+    assert float(out.loc) == pytest.approx(0.3)
+    assert float(out.scale) == pytest.approx(0.7)
+
+
+def test_exp_normal_mc_mean_matches_lognormal_closed_form():
+    """``E[exp(N(mu, sigma))] = exp(mu + sigma^2/2)``."""
+    mu, sigma = 0.4, 0.5
+    n = Normal(loc=jnp.asarray(mu), scale=jnp.asarray(sigma), name="x")
+    out = pushforward(Exp(), n)
+    key = jax.random.key(1)
+    s = sample(out, key=key, sample_shape=(20_000,))
+    expected_mean = float(jnp.exp(mu + 0.5 * sigma ** 2))
+    assert float(jnp.mean(s)) == pytest.approx(expected_mean, rel=0.05)
+
+
+# -------------------------------------------------------------------------
+# Closed-form: (Log, LogNormal) -> Normal
+# -------------------------------------------------------------------------
+
+
+def test_log_lognormal_returns_normal_with_same_loc_scale():
+    ln = LogNormal(loc=jnp.asarray(-0.2), scale=jnp.asarray(1.1), name="x")
+    out = pushforward(Log(), ln)
+    assert isinstance(out, Normal)
+    assert float(out.loc) == pytest.approx(-0.2)
+    assert float(out.scale) == pytest.approx(1.1)
+
+
+# -------------------------------------------------------------------------
+# Compose: (f @ g, dist) recurses
+# -------------------------------------------------------------------------
+
+
+def test_compose_recursion_matches_manual_chain():
+    """``pushforward(f @ g, dist)`` matches
+    ``pushforward(f, pushforward(g, dist))``."""
+    n = Normal(loc=jnp.asarray(0.0), scale=jnp.asarray(1.0), name="x")
+    f = Affine(slope=2.0, intercept=3.0)
+    g = Affine(slope=-1.0, intercept=0.5)
+    out_compose = pushforward(f @ g, n)
+    out_manual = pushforward(f, pushforward(g, n))
+    assert isinstance(out_compose, Normal)
+    assert float(out_compose.loc) == pytest.approx(float(out_manual.loc))
+    assert float(out_compose.scale) == pytest.approx(float(out_manual.scale))
+
+
+def test_compose_mixed_closed_then_mc_returns_empirical():
+    """``Affine @ LogSoftplus`` through MVN: LogSoftplus falls to MC,
+    Affine applies closed-form on the resulting empirical distribution.
+    Per ``docs/link_functions.md`` §5.4."""
+    L = jnp.eye(3)
+    mvn = MultivariateNormal(loc=jnp.zeros(3), scale_tril=L, name="x")
+    intercept = jnp.asarray([1.0, -1.0, 0.5])
+    m = Affine(slope=2.0, intercept=intercept) @ LogSoftplus()
+    out = pushforward(m, mvn)
+    assert isinstance(out, NumericEmpiricalDistribution)
+    assert out.event_shape == (3,)
+    # Each output coord is `2 * LogSoftplus(z_i) + intercept_i` with
+    # `z_i ~ N(0, 1)` iid. So the variance is `4 * Var[LogSoftplus(N(0,1))]`,
+    # the *same* across coords; subtracting the per-coord mean removes the
+    # intercept and leaves a stationary, zero-mean per-coord sample.
+    centered = out._samples - jnp.mean(out._samples, axis=0)
+    per_coord_var = jnp.var(centered, axis=0)
+    # All per-coord variances should be close to each other.
+    assert jnp.allclose(per_coord_var, per_coord_var[0], rtol=0.5)
+
+
+# -------------------------------------------------------------------------
+# MC fallback
+# -------------------------------------------------------------------------
+
+
+def test_mc_fallback_log_softplus_normal_returns_empirical():
+    n = Normal(loc=jnp.asarray(1.0), scale=jnp.asarray(0.5), name="x")
+    out = pushforward(LogSoftplus(), n)
+    assert isinstance(out, NumericEmpiricalDistribution)
+    assert out.event_shape == ()
+    # All samples are finite: log(softplus(z)) is finite for z away from -inf.
+    assert jnp.all(jnp.isfinite(out._samples))
+
+
+def test_mc_fallback_log_softplus_mvn_returns_empirical_with_correct_event_shape():
+    L = jnp.eye(3)
+    mvn = MultivariateNormal(loc=jnp.zeros(3), scale_tril=L, name="x")
+    out = pushforward(LogSoftplus(), mvn)
+    assert isinstance(out, NumericEmpiricalDistribution)
+    assert out.event_shape == (3,)
+
+
+# -------------------------------------------------------------------------
+# Unregistered + non-samplable input raises
+# -------------------------------------------------------------------------
+
+
+def test_unregistered_non_samplable_input_raises():
+    """Without a ``SupportsSampling`` input there's no MC fallback path."""
+
+    class _NonSamplable:
+        """Looks like a Distribution but doesn't implement SupportsSampling."""
+
+        pass
+
+    with pytest.raises(NotImplementedError, match="no dispatch path"):
+        pushforward(LogSoftplus(), _NonSamplable())  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #64.

## Summary

Phase 2 from [`docs/link_functions.md`](docs/link_functions.md) — lands the `Map` abstraction and the `pushforward(map, dist)` multi-dispatch op that #63's implementation and the link-function refactor (#65) depend on. **Primitives only**: no changes to `forms.py`, `target_distribution.py`, `surrogate/`, `tempering/`, or `acquisitions/`.

- `Map` ABC with `event_shape_in` / `event_shape_out`, broadcasting contract, and `@` composition via `Compose`.
- Twelve concrete maps:
  - Linear/constant: `Identity`, `Constant`, `Affine`, `Compose`.
  - Elementwise: `Exp`, `Log`, `Softplus`, `LogSoftplus`, `Square`, `LogSquare`.
  - Closed over parameters: `GaussianLogLik`, `LogProb`.
- `pushforward(map, dist)` op — multi-dispatch on `(type(map), type(dist))`, MRO-walk lookup. Closed-form registrations:
  - `(Identity, *)` → unchanged.
  - `(Constant(c), *)` → `Dirac(c)`.
  - `(Affine, Normal | MVN | NumericEmpiricalDistribution)` — analytic.
  - `(Exp, Normal)` → `LogNormal`.
  - `(Log, LogNormal)` → `Normal`.
  - `(Compose, *)` — recurse.
  - Anything else with a `SupportsSampling` input falls to the `@workflow_function`-driven MC path (generalises today's `_batch_form` from `sabi/surrogate/_pushforward.py`).
- `Dirac` Distribution shim — single-atom subclass of `NumericEmpiricalDistribution`. Retires when ProbPipe ships one.

## Deviations from the issue

- **`(Square, Normal)` -> non-central chi-squared** is deferred to Phase 7 per `docs/link_functions.md` §9. ProbPipe doesn't ship a `NoncentralChi2` distribution, and the design doc explicitly assigns the closed-form pushforward to the square-link-end-to-end work. `(Square, Normal)` falls to the MC path in this PR.

## Tests

- 31 unit tests in `tests/test_maps.py`: per-map `__call__` correctness, `event_shape_in/out` contract, batched broadcasting, `Compose` (associativity, identity, shape-mismatch error).
- 14 unit tests in `tests/test_pushforward.py`: each closed-form entry validated by direct parameter equality plus MC-mean/variance agreement at ~5% tolerance; MC fallback shape and finiteness; `Compose` recursion (closed-form chain + the §5.4 worked example through MC); unregistered-non-samplable raises.
- Full suite: 393 passed, 5 skipped (no regressions).
- Sphinx `-W -b html` build clean (no new warnings from this PR).

## Test plan
- [x] `./scripts/python -m pytest -q` passes
- [x] `./scripts/python -m sphinx -W -b html docs docs/_build/html` succeeds
- [x] `./scripts/python -m ruff check src/sabi/maps tests/test_maps.py tests/test_pushforward.py` clean
- [x] Reviewer to confirm the `(Square, Normal)` deferral is acceptable.
